### PR TITLE
Fix lingering for ceres

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -23,13 +23,4 @@ do_install_append() {
     install -m 0644 ${WORKDIR}/dbus.conf ${D}/etc/systemd/system/user@.service.d/dbus.conf
 }
 
-pkg_postinst_${PN}() {
-#!/bin/sh -e
-if [ x"$D" = "x" ]; then
-    loginctl enable-linger ceres
-else
-    exit 1
-fi
-}
-
 PACKAGECONFIG_append += "pam"

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -11,6 +11,8 @@ do_install_append() {
     install -m 0644 ${WORKDIR}/65-android.rules ${D}${sysconfdir}/udev/rules.d/65-android.rules
 
     # Enables auto-login for ceres
+    install -d ${D}/var/lib/systemd/linger
+    touch ${D}/var/lib/systemd/linger/ceres
     sed -i "s@agetty --noclear @agetty --autologin ceres @" ${D}/lib/systemd/system/getty@.service
    
     # In current systemd versions we have to take care ourselves of the dbus user service, it should be handled in the next versions


### PR DESCRIPTION
This lets systemd allow lingering for the ceres user.
Asteroid-launcher will start on boot and will continue running without login sessions.