### PR TITLE
Point contextkit to the mer-core-attic

### DIFF
--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-contextkit_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-contextkit_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://git.merproject.org/mer-core/nemo-qml-plugin-contextkit"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://src/plugin.cpp;beginline=1;endline=23;md5=bc596f90d6ca301d84447f4d365b9243"
 
-SRC_URI = "git://git.merproject.org/mer-core/nemo-qml-plugin-contextkit.git;protocol=https"
+SRC_URI = "git://git.merproject.org/mer-core-attic/nemo-qml-plugin-contextkit.git;protocol=https"
 SRCREV = "ea0485fd84f5851d0671cfb3d2b9cec10a048890"
 PR = "r1"
 PV = "+git${SRCREV}"


### PR DESCRIPTION
Git repository changed upstream:

ERROR: Fetcher failure: Fetch command failed with exit code 128, output:
Cloning into bare repository '/home/asteroid/workspace/asteroid-image-bass/build/downloads/git2/git.merproject.org.mer-core.nemo-qml-plugin-contextkit.git'...
fatal: could not read Username for 'https://git.merproject.org': No such device or address

ERROR: Function failed: Fetcher failure for URL: 'git://git.merproject.org/mer-core/nemo-qml-plugin-contextkit.git;protocol=https'. Unable to fetch URL from any source.