### PR TITLE
Add i18n support

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -7,7 +7,7 @@ IMAGE_FEATURES += "splash package-management"
 IMAGE_INSTALL += " \
 base-files base-passwd shadow systemd tzdata coreutils bash file findutils gawk grep procps psmisc sed util-linux sudo module-init-tools less tar gzip bzip2 \
 iproute2 connman bluez5 pulseaudio dropbear qtbase-plugins statefs dsme mce ngfd timed sensorfw android-init mapplauncherd-booster-qtcomponents usb-moded \
-asteroid-launcher asteroid-calculator asteroid-calendar asteroid-stopwatch asteroid-settings asteroid-timer asteroid-alarmclock asteroid-btsyncd"
+supported-languages asteroid-launcher asteroid-calculator asteroid-calendar asteroid-stopwatch asteroid-settings asteroid-timer asteroid-alarmclock asteroid-btsyncd"
 
 EXTRA_USERS_PARAMS = "groupadd system; \
                       groupadd statefs; \

--- a/recipes-asteroid/asteroid-calendar/asteroid-calendar_git.bb
+++ b/recipes-asteroid/asteroid-calendar/asteroid-calendar_git.bb
@@ -10,4 +10,5 @@ PV = "+git${SRCREV}"
 S = "${WORKDIR}/git"
 inherit qmake5
 
+RDEPENDS_${PN} += "qtquickcontrols-qmlplugins"
 DEPENDS += "qml-asteroid mapplauncherd-booster-qtcomponents qtquickcontrols"

--- a/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
+++ b/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
@@ -11,4 +11,4 @@ S = "${WORKDIR}/git"
 inherit qmake5
 
 DEPENDS += "qml-asteroid nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus qtconnectivity mapplauncherd-booster-qtcomponents"
-RDEPENDS_${PN} += "qtconnectivity-qmlplugins nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus"
+RDEPENDS_${PN} += "qtconnectivity-qmlplugins nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus qtquickcontrols-qmlplugins"

--- a/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
+++ b/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
@@ -12,3 +12,10 @@ inherit qmake5
 
 DEPENDS += "qml-asteroid nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus qtconnectivity mapplauncherd-booster-qtcomponents"
 RDEPENDS_${PN} += "qtconnectivity-qmlplugins nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus qtquickcontrols-qmlplugins"
+FILES_${PN} += "/usr/share/translations/"
+
+do_install_append() {
+    lrelease ${S}/asteroid-settings.pro
+    install -d ${D}/usr/share/translations/
+    cp ${S}/asteroid-settings.*.qm ${D}/usr/share/translations/
+}

--- a/recipes-asteroid/supported-languages/supported-languages/locale.conf
+++ b/recipes-asteroid/supported-languages/supported-languages/locale.conf
@@ -1,0 +1,2 @@
+# This is the default locale
+LANG=en_GB.utf8

--- a/recipes-asteroid/supported-languages/supported-languages/localeEnv.conf
+++ b/recipes-asteroid/supported-languages/supported-languages/localeEnv.conf
@@ -1,0 +1,2 @@
+[Service]
+EnvironmentFile=/var/lib/environment/ceres/locale.conf

--- a/recipes-asteroid/supported-languages/supported-languages_git.bb
+++ b/recipes-asteroid/supported-languages/supported-languages_git.bb
@@ -1,0 +1,31 @@
+SUMMARY = "Set of config files describing the languages that are available on AsteroidOS"
+HOMEPAGE = "https://github.com/AsteroidOS/supported-languages"
+LICENSE = "CC0-1.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=65d3616852dbf7b1a6d4b53b00626032"
+
+SRC_URI = "git://github.com/AsteroidOS/supported-languages.git;protocol=https \
+    file://locale.conf \
+    file://localeEnv.conf"
+SRCREV = "${AUTOREV}"
+PR = "r1"
+PV = "+git${SRCREV}"
+S = "${WORKDIR}/git"
+
+FILES_${PN} += "/etc/systemd/system/user@.service.d/ /usr/lib/systemd/user/ /usr/share/jolla-supported-languages/"
+
+INSANE_SKIP_${PN} += "host-user-contaminated"
+
+do_install_append() {
+    install -d ${D}/etc/systemd/system/user@.service.d/
+    cp ../localeEnv.conf ${D}/etc/systemd/system/user@.service.d/locale.conf
+
+    install -d ${D}/var/lib/environment/ceres/
+    cp ../locale.conf ${D}/var/lib/environment/ceres/locale.conf
+
+    # TODO: Ensure this only allows asteroid-settings to write to this file, so
+    # that others apps cannot set environment variables
+    chown 1000:1000 ${D}/var/lib/environment/ceres/locale.conf # ceres:ceres
+
+    install -d ${D}/usr/share/jolla-supported-languages/
+    cp ${S}/*.conf ${D}/usr/share/jolla-supported-languages/
+}


### PR DESCRIPTION
Adds global i18n support and builds the translations for the settings app. Currently non-functional. DO NOT MERGE.

In my idea, this should make i18n work. It at least puts all the files on the right spot with the correct rights. Unfortunately, after building and testing this, I got the following error on my device when trying to launch any app: `lipstick[850]: wl_event_loop_dispatch error: -1`. Why this happens is beyond me.

The build script also returns 2 QA warnings:
```
WARNING: QA Issue: python-pygobject: /python-pygobject/usr/lib/python2.7/site-packages/pygtk.pth is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination [host-user-contaminated]
WARNING: QA Issue: asteroid-launcher: /asteroid-launcher/var/lib/environment/ceres/locale.conf is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination [host-user-contaminated]
```

These warnings are caused by doing a chown 1000:1000 to make ceres the owner at a point of the build script where the user ceres does not exist yet.

This pull request is supposed to accompany https://github.com/AsteroidOS/asteroid-settings/pull/1. While this breaks app launching on my device, I really can't figure out why, so I'm making this pull request to simplify giving feedback for the time being so this issue can be resolved.