### PR TITLE
Fix building languages

### DIFF
--- a/recipes-asteroid/asteroid-alarmclock/asteroid-alarmclock_git.bb
+++ b/recipes-asteroid/asteroid-alarmclock/asteroid-alarmclock_git.bb
@@ -15,7 +15,7 @@ RDEPENDS_${PN} += "nemo-qml-plugin-alarms"
 FILES_${PN} += "/usr/share/translations/"
 
 do_install_append() {
-    lrelease ${S}/asteroid-alarmclock.pro
+    lrelease ${S}/asteroid-alarmclock.*.ts
     install -d ${D}/usr/share/translations/
     cp ${S}/asteroid-alarmclock.*.qm ${D}/usr/share/translations/
 }

--- a/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
+++ b/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
@@ -15,7 +15,7 @@ RDEPENDS_${PN} += "qtconnectivity-qmlplugins nemo-qml-plugin-systemsettings nemo
 FILES_${PN} += "/usr/share/translations/"
 
 do_install_append() {
-    lrelease ${S}/asteroid-settings.pro
+    lrelease ${S}/asteroid-settings.*.ts
     install -d ${D}/usr/share/translations/
     cp ${S}/asteroid-settings.*.qm ${D}/usr/share/translations/
 }


### PR DESCRIPTION
lrelease seems unable to read wildcards in a .pro file, so we directly
tell it to just translate all translations

As per documentation on http://linuxcommand.org/man_pages/lrelease1.html.

This means the TRANSLATIONS entry in the .pro files are unnecessary.