### PR TITLE
Remove absolute dir from build definition

### DIFF
--- a/recipes-nemomobile/sensorfw/sensorfw_git.bb
+++ b/recipes-nemomobile/sensorfw/sensorfw_git.bb
@@ -14,6 +14,7 @@ inherit qmake5
 do_configure_prepend() {
     sed -i '/include( doc\/doc.pri )/d' ../git/sensorfw.pro
     sed -i 's@=/usr/include/android@=${STAGING_DIR_TARGET}/usr/include/android@' ../git/core/hybris.pro ../git/config.tests/hybris/hybris.pro ../git/adaptors/hybrisproximityadaptor/hybrisproximityadaptor.pro ../git/adaptors/hybrisorientationadaptor/hybrisorientationadaptor.pro ../git/adaptors/hybrismagnetometeradaptor/hybrismagnetometeradaptor.pro ../git/adaptors/hybrisgyroscopeadaptor/hybrisgyroscopeadaptor.pro ../git/adaptors/hybrisalsadaptor/hybrisalsadaptor.pro ../git/adaptors/hybrisaccelerometer/hybrisaccelerometer.pro
+    sed -i 's:-L/usr/lib ::' ../git/core/hybris.pro
 }
 
 do_install_append() {


### PR DESCRIPTION
Before this change I got a failure:

```
| /home/dlan/local/src/asteroid/build/tmp-glibc/sysroots/x86_64-linux/usr/libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/6.2.0/ld: warning: library search path "/usr/lib" is unsafe fo
r cross-compilation
| /usr/lib/libQt5Network.so: file not recognized: File format not recognized
```