### PR TITLE
Fix issue with adbd patch striplevel

### DIFF
--- a/recipes-devtools/android-tools/android-tools_%.bbappend
+++ b/recipes-devtools/android-tools/android-tools_%.bbappend
@@ -1,2 +1,2 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/android-tools:"
-SRC_URI += " file://0001-Allow-adbd-to-be-ran-as-root.patch "
+SRC_URI += " file://0001-Allow-adbd-to-be-ran-as-root.patch;striplevel=1 "


### PR DESCRIPTION
0001-Allow-adbd-to-be-ran-as-root.patch contains paths with 'a/', 'b/' prefixes which need to be stripped.

Buildlog snippet:
https://gist.github.com/theappleman/1554e48bc17d32cf88faae3eb94587cd