### PR TITLE
Add missing "bison-native" dependency to kcalcore_git.

### DIFF
--- a/recipes-qt/qt5/kcalcore_git.bb
+++ b/recipes-qt/qt5/kcalcore_git.bb
@@ -11,4 +11,4 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 inherit qmake5
 
-DEPENDS += "qtbase timed libical"
+DEPENDS += "qtbase timed libical bison-native"


### PR DESCRIPTION
Without this dependency, the build task for kcalcore_git was unable to find 'yacc' on my system.