### PR TITLE
usb-moded: Fix ADB service not starting properly.

### DIFF
--- a/recipes-nemomobile/usb-moded/usb-moded_git.bb
+++ b/recipes-nemomobile/usb-moded/usb-moded_git.bb
@@ -28,7 +28,7 @@ RDEPENDS_${PN} += "buteo-mtp"
 do_configure_prepend() {
     sed -i "s@systemd-daemon@systemd@" configure.ac
     sed -i "s@shell@ceres@g" systemd/adbd-functionfs.sh
-    sed -i "s@ adbd.service@ android-tools-adbd.service@" ${S}/systemd/adbd-prepare.service
+    sed -i "s@adbd.service@android-tools-adbd.service@" ${S}/systemd/adbd-prepare.service
     sed -i "s@umount adb@umount /dev/usb-ffs/adb@" ${S}/systemd/adbd-prepare.service
 }
 
@@ -72,6 +72,8 @@ do_install_append() {
 
     install -d ${D}/var/lib/misc/
     touch ${D}/var/lib/misc/udhcpd.leases
+
+    touch ${D}/var/usb-debugging-enabled
 }
 
 FILES_${PN} += " /lib/systemd/system /usr/share/dbus-1/services/ /var/lib/misc/udhcpd.leases"


### PR DESCRIPTION
ADB wasn't working for sturgeon, digging around in the service files made it clear that ADB might not work for all AsteroidOS builds.
When selecting ADB mode from the UI I get this error on my PC:
usb 1-1: new high-speed USB device number 20 using xhci_hcd
**usb 1-1: config 1 has no interfaces?**
usb 1-1: New USB device found, idVendor=18d1, idProduct=0a03, bcdDevice=ff.ff
usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
usb 1-1: Product: HUAWEI WATCH
usb 1-1: Manufacturer: HUAWEI

This pull request solves the problem at least for sturgeon. Can you maybe test this on other platforms? I will make a pull request for sturgeon if this only affects the sturgeon platform.


Interesting service files are located here:
https://git.sailfishos.org/mer-core/usb-moded/blob/master/systemd/adbd-prepare.service
https://github.com/openembedded/meta-openembedded/blob/warrior/meta-oe/recipes-devtools/android-tools/android-tools/android-tools-adbd.service