### PR TITLE
Add support for Bluetooth HID and Audio

### DIFF
--- a/recipes-connectivity/bluez5/bluez5/input.conf
+++ b/recipes-connectivity/bluez5/bluez5/input.conf
@@ -1,0 +1,13 @@
+# Configuration file for the input service
+
+# This section contains options which are not specific to any
+# particular interface
+[General]
+
+# Set idle timeout (in minutes) before the connection will
+# be disconnect (defaults to 0 for no timeout)
+#IdleTimeout=30
+
+# Enable HID protocol handling in userspace input profile
+# Defaults to false (HIDP handled in HIDP kernel module)
+UserspaceHID=true

--- a/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -2,11 +2,13 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/bluez5:"
 SRC_URI += "file://main.conf \
             file://bluetooth.service \
             file://bluetooth.conf \
+            file://input.conf \
             file://0001-Advertise-hostname-in-BLE-ad-payload-to-have-a-recog.patch"
 
 do_install_append() {
     install -d ${D}/etc/bluetooth/
     cp ${WORKDIR}/main.conf ${D}/etc/bluetooth/main.conf
+    cp ${WORKDIR}/input.conf ${D}/etc/bluetooth/input.conf
 
     install -d ${D}/lib/systemd/system/
     cp ${WORKDIR}/bluetooth.service ${D}/lib/systemd/system/bluetooth.service

--- a/recipes-multimedia/pulseaudio/pulseaudio/default.pa
+++ b/recipes-multimedia/pulseaudio/pulseaudio/default.pa
@@ -33,6 +33,23 @@ load-module module-match table=/etc/pulse/x-maemo-match.table key=application.na
 load-module module-droid-card source_channel_map=mono
 .endif
 
+### Automatically load driver modules for Bluetooth hardware
+.ifexists module-bluetooth-policy.so
+load-module module-bluetooth-policy
+.endif
+
+.ifexists module-bluetooth-discover.so
+load-module module-bluetooth-discover
+.endif
+
+#.ifexists module-bluez5-device.so
+#load-module module-bluez5-device
+#.endif
+
+.ifexists module-bluez5-discover.so
+load-module module-bluez5-discover
+.endif
+
 ### Automatically restore the volume of streams and devices
 load-module module-device-restore
 
@@ -41,6 +58,9 @@ load-module module-device-restore
 ### NOTE: This should be loaded as early as possible so that subsequent modules
 ### that look up the default sink/source get the right value
 load-module module-default-device-restore
+
+### Should be after module-*-restore
+load-module module-switch-on-port-available
 
 ### Automatically move streams to the default sink if the sink they are
 ### connected to dies, similar for sources

--- a/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -1,5 +1,4 @@
-RDEPENDS_pulseaudio-server_append = " pulseaudio-modules-nemo pulseaudio-module-dbus-protocol pulseaudio-module-match "
-
+RDEPENDS_pulseaudio-server_append = " pulseaudio-modules-nemo pulseaudio-module-dbus-protocol pulseaudio-module-match pulseaudio-module-switch-on-connect pulseaudio-module-bluetooth-discover pulseaudio-module-bluetooth-policy pulseaudio-module-bluez5-discover pulseaudio-module-bluez5-device "
 FILESEXTRAPATHS_prepend := "${THISDIR}/pulseaudio:"
 SRC_URI += "file://1002-build-Install-pulsecore-headers.patch \
             file://mainvolume-listening-time-notifier.conf \


### PR DESCRIPTION
This PR includes the needed changes to allow for Bluetooth HID and Audio to work.

A seperate adjustment is needed to patchram.service to fix extreme skipping. That adjustment consists of setting a baudrate. I will make a followup PR for sturgeon with this fix.

You may want to change ControllerMode = le to dual, in main.conf, if a Bluetooth peripheral is not visible when scanning. This is not included in this PR as that change may impact battery life.
We may document this on the asteroidos.org wiki or I think it will be cool if we can change the controller mode in asteroid-settings. Maybe even add the ability to connect Bluetooth peripherals via asteroid-settings :)