### PR TITLE
resize-rootfs: Expand rootfs when installed on userdata.

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -5,7 +5,7 @@ LICENSE = "GPL-2.0"
 IMAGE_FEATURES += "package-management debug-tweaks"
 
 IMAGE_INSTALL += " \
-base-files base-passwd systemd busybox iproute2 connman pam-plugin-loginuid bluez5 pulseaudio-server openssh-sshd openssh-sftp-server openssh-scp statefs dsme mce ngfd timed sensorfw android-init mapplauncherd-booster-qtcomponents usb-moded ofono \
+base-files base-passwd systemd busybox iproute2 connman pam-plugin-loginuid bluez5 pulseaudio-server openssh-sshd openssh-sftp-server openssh-scp statefs dsme mce ngfd timed sensorfw android-init resize-rootfs mapplauncherd-booster-qtcomponents usb-moded ofono \
 supported-languages asteroid-launcher asteroid-calculator asteroid-calendar asteroid-stopwatch asteroid-settings asteroid-timer asteroid-alarmclock asteroid-weather asteroid-music asteroid-btsyncd asteroid-flashlight"
 
 EXTRA_USERS_PARAMS = "groupadd system; \

--- a/recipes-core/resize-rootfs/resize-rootfs/resize_rootfs
+++ b/recipes-core/resize-rootfs/resize-rootfs/resize_rootfs
@@ -1,0 +1,8 @@
+#!/bin/sh
+root=$(mount | grep "on / " | awk -F' ' '{print $1}')
+if [[ $root == *"sdcard"* ]]; then
+  echo "Running on temporary installation, ignoring resize of filesystem."
+else
+  echo "Resizing root partition to fill userdata..."
+  resize2fs $root
+fi

--- a/recipes-core/resize-rootfs/resize-rootfs_git.bb
+++ b/recipes-core/resize-rootfs/resize-rootfs_git.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Resize rootfs to fill userdata partition."
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install_append() {
+    install -d ${D}${bindir}
+    cp ${WORKDIR}/resize_rootfs ${D}${bindir}
+}
+
+pkg_postinst_ontarget_${PN}() {
+    /usr/bin/resize_rootfs
+}
+
+RDEPENDS_${PN} += "e2fsprogs-resize2fs"


### PR DESCRIPTION
This PR adds a script that uses resize2fs to resize the rootfs to fill the userdata partition when installed on userdata.
When this script is executed on a temporary installation it will exit without using resize2fs.

This PR possibly implements #16.

Please let me know if this PR fulfills the quality requirements to be merged with meta-asteroid.

Couple of uncertainties from my end:
- Is the script located at the proper location(/usr/bin) or should I move this to a reserved location(/var)
- This PR does not incorporate a reboot mechanism. I noticed that Raspbian and Armbian warn that the system should be rebooted when on-line resize is performed.
