### PR TITLE
openssh: fix login on old kernels with openssl 1.1.1d

### DIFF
--- a/recipes-connectivity/openssh/openssh/0001-Deny-non-fatal-shmget-shmat-shmdt-in-preauth-privsep.patch
+++ b/recipes-connectivity/openssh/openssh/0001-Deny-non-fatal-shmget-shmat-shmdt-in-preauth-privsep.patch
@@ -1,0 +1,37 @@
+From 3ef92a657444f172b61f92d5da66d94fa8265602 Mon Sep 17 00:00:00 2001
+From: Lonnie Abelbeck <lonnie@abelbeck.com>
+Date: Tue, 1 Oct 2019 09:05:09 -0500
+Subject: [PATCH] Deny (non-fatal) shmget/shmat/shmdt in preauth privsep child.
+
+New wait_random_seeded() function on OpenSSL 1.1.1d uses shmget, shmat, and shmdt
+in the preauth codepath, deny (non-fatal) in seccomp_filter sandbox.
+---
+
+Source: https://github.com/openssh/openssh-portable/commit/3ef92a657444f172b61f92d5da66d94fa8265602
+
+ sandbox-seccomp-filter.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/sandbox-seccomp-filter.c b/sandbox-seccomp-filter.c
+index 840c5232..39dc289e 100644
+--- a/sandbox-seccomp-filter.c
++++ b/sandbox-seccomp-filter.c
+@@ -168,6 +168,15 @@ static const struct sock_filter preauth_insns[] = {
+ #ifdef __NR_stat64
+ 	SC_DENY(__NR_stat64, EACCES),
+ #endif
++#ifdef __NR_shmget
++	SC_DENY(__NR_shmget, EACCES),
++#endif
++#ifdef __NR_shmat
++	SC_DENY(__NR_shmat, EACCES),
++#endif
++#ifdef __NR_shmdt
++	SC_DENY(__NR_shmdt, EACCES),
++#endif
+ 
+ 	/* Syscalls to permit */
+ #ifdef __NR_brk
+-- 
+2.23.0
+

--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/openssh:"
+SRC_URI += "file://0001-Deny-non-fatal-shmget-shmat-shmdt-in-preauth-privsep.patch"


### PR DESCRIPTION
It looks like OpenSSL was updated to 1.1.1d from oe-core (https://github.com/openembedded/openembedded-core/commits/warrior). This appears to break OpenSSH with older kernels.
A fix has already been made upstream. This should be included in 8.2 release. I think it will take some time before we get this release in the warrior branch.

Instead of using this patch, we may also freeze the oe-core (https://github.com/AsteroidOS/asteroid/blob/master/prepare-build.sh#L74) to a specific SRCREV. This makes everything less susceptible to bugs in the oe-core branch at the cost of having outdated packages.

This patch will also need to be removed when we inevitably get the OpenSSH 8.2 release in the oe-core repo.

This also fixes https://github.com/AsteroidOS/meta-mtk6580-hybris/issues/8

References:
https://github.com/z3ntu/aports/commit/ccc44317fa09f12c982b5d91aba374e81725bea6
https://github.com/openssl/openssl/issues/9984
https://github.com/openssh/openssh-portable/pull/149