### PR TITLE
libsdl2: fix compilation and runtime errors.

### DIFF
--- a/recipes-graphics/libsdl2/libsdl2/0001-wayland-support-wl_data_device_manager-version-3.patch
+++ b/recipes-graphics/libsdl2/libsdl2/0001-wayland-support-wl_data_device_manager-version-3.patch
@@ -1,0 +1,69 @@
+From 887f98ae5d4cc59eca40505381b9df06a582e387 Mon Sep 17 00:00:00 2001
+From: Michael Forney <mforney@mforney.org>
+Date: Sun, 29 Dec 2019 23:10:39 -0800
+Subject: [PATCH] wayland: support wl_data_device_manager version < 3
+
+---
+ src/video/wayland/SDL_waylanddyn.h    | 1 +
+ src/video/wayland/SDL_waylandevents.c | 6 ++++--
+ src/video/wayland/SDL_waylandsym.h    | 1 +
+ src/video/wayland/SDL_waylandvideo.c  | 2 +-
+ 4 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/src/video/wayland/SDL_waylanddyn.h b/src/video/wayland/SDL_waylanddyn.h
+index b8707f0a7..d4d8f0bf3 100644
+--- a/src/video/wayland/SDL_waylanddyn.h
++++ b/src/video/wayland/SDL_waylanddyn.h
+@@ -74,6 +74,7 @@ void SDL_WAYLAND_UnloadSymbols(void);
+ #define wl_proxy_marshal (*WAYLAND_wl_proxy_marshal)
+ #define wl_proxy_set_user_data (*WAYLAND_wl_proxy_set_user_data)
+ #define wl_proxy_get_user_data (*WAYLAND_wl_proxy_get_user_data)
++#define wl_proxy_get_version (*WAYLAND_wl_proxy_get_version)
+ #define wl_proxy_add_listener (*WAYLAND_wl_proxy_add_listener)
+ #define wl_proxy_marshal_constructor (*WAYLAND_wl_proxy_marshal_constructor)
+ #define wl_proxy_marshal_constructor_versioned (*WAYLAND_wl_proxy_marshal_constructor_versioned)
+diff --git a/src/video/wayland/SDL_waylandevents.c b/src/video/wayland/SDL_waylandevents.c
+index 013ac660b..1729a3a11 100644
+--- a/src/video/wayland/SDL_waylandevents.c
++++ b/src/video/wayland/SDL_waylandevents.c
+@@ -809,8 +809,10 @@ data_device_handle_enter(void *data, struct wl_data_device *wl_data_device,
+         if (has_mime == SDL_TRUE) {
+             dnd_action = WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY;
+         }
+-        wl_data_offer_set_actions(data_device->drag_offer->offer,
+-                                  dnd_action, dnd_action);
++        if (wl_data_offer_get_version(data_device->drag_offer->offer) >= 3) {
++            wl_data_offer_set_actions(data_device->drag_offer->offer,
++                                      dnd_action, dnd_action);
++        }
+     }
+ }
+ 
+diff --git a/src/video/wayland/SDL_waylandsym.h b/src/video/wayland/SDL_waylandsym.h
+index bae46a38f..3bd9dc045 100644
+--- a/src/video/wayland/SDL_waylandsym.h
++++ b/src/video/wayland/SDL_waylandsym.h
+@@ -40,6 +40,7 @@ SDL_WAYLAND_SYM(void, wl_proxy_destroy, (struct wl_proxy *))
+ SDL_WAYLAND_SYM(int, wl_proxy_add_listener, (struct wl_proxy *, void (**)(void), void *))
+ SDL_WAYLAND_SYM(void, wl_proxy_set_user_data, (struct wl_proxy *, void *))
+ SDL_WAYLAND_SYM(void *, wl_proxy_get_user_data, (struct wl_proxy *))
++SDL_WAYLAND_SYM(uint32_t, wl_proxy_get_version, (struct wl_proxy *))
+ SDL_WAYLAND_SYM(uint32_t, wl_proxy_get_id, (struct wl_proxy *))
+ SDL_WAYLAND_SYM(const char *, wl_proxy_get_class, (struct wl_proxy *))
+ SDL_WAYLAND_SYM(void, wl_proxy_set_queue, (struct wl_proxy *, struct wl_event_queue *))
+diff --git a/src/video/wayland/SDL_waylandvideo.c b/src/video/wayland/SDL_waylandvideo.c
+index c85860614..7165df0b3 100644
+--- a/src/video/wayland/SDL_waylandvideo.c
++++ b/src/video/wayland/SDL_waylandvideo.c
+@@ -381,7 +381,7 @@ display_handle_global(void *data, struct wl_registry *registry, uint32_t id,
+     } else if (strcmp(interface, "zwp_pointer_constraints_v1") == 0) {
+         Wayland_display_add_pointer_constraints(d, id);
+     } else if (strcmp(interface, "wl_data_device_manager") == 0) {
+-        d->data_device_manager = wl_registry_bind(d->registry, id, &wl_data_device_manager_interface, 3);
++        d->data_device_manager = wl_registry_bind(d->registry, id, &wl_data_device_manager_interface, SDL_min(3, version));
+ 
+ #ifdef SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH
+     } else if (strcmp(interface, "qt_touch_extension") == 0) {
+-- 
+2.25.0
+

--- a/recipes-graphics/libsdl2/libsdl2_%.bbappend
+++ b/recipes-graphics/libsdl2/libsdl2_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/libsdl2:"
+SRC_URI_append = "file://0001-wayland-support-wl_data_device_manager-version-3.patch"
+
+PACKAGECONFIG_remove = "opengl"


### PR DESCRIPTION
OpenGL is enabled in DISTRO_FEATURES. But opengl isn't actually provided by libhybris.
We also need an upstream patch to fix runtime errors with older wayland protocol specs.

This fixes the following runtime issue:
wl_registry@2: error 0: invalid version for global wl_data_device_manager (4): have 1, wanted 3