### PR TITLE
ngfd-plugin-droid-vibrator: Rename alarm to clock.

### DIFF
--- a/recipes-nemomobile/ngfd/ngfd-plugin-droid-vibrator/50-droid-vibrator.ini
+++ b/recipes-nemomobile/ngfd/ngfd-plugin-droid-vibrator/50-droid-vibrator.ini
@@ -1,7 +1,7 @@
 [droid-vibrator]
 
 # For each string in EFFECT_LIST define a sequence
-EFFECT_LIST = touch,short,strong,long,notice,message,attention,alarm,ringtone,default
+EFFECT_LIST = touch,short,strong,long,notice,message,attention,clock,ringtone,default
 
 # Sequence has following syntax:
 #  sequence_name = <action>=<value>
@@ -24,6 +24,6 @@ long     = on=800
 notice   = on=100,pause=500,repeat=1
 message  = on=200,pause=200,repeat=1
 attention= on=100,pause=100,repeat=2
-alarm    = on=1000,pause=500,repeat=forever
+clock    = on=1000,pause=500,repeat=forever
 ringtone = on=2000,pause=500,repeat=forever
 default  = on=66


### PR DESCRIPTION
The ffmemless version uses the clock pattern for alarm events.
This caused alarm.ini to refer to effect = clock. Which does not exist for the non-ffmemless version.
Renaming the alarm event to clock fixes this issue.

This should fix https://github.com/AsteroidOS/meta-wren-hybris/issues/3 and fix https://github.com/AsteroidOS/meta-lenok-hybris/issues/6