### PR TITLE
rootfs: Reduce free space.

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -15,4 +15,4 @@ EXTRA_USERS_PARAMS = "groupadd system; \
                       useradd -p '' -G 'audio,video,system,gps,statefs,mtp' ceres"
 
 IMAGE_OVERHEAD_FACTOR = "1.0"
-IMAGE_ROOTFS_EXTRA_SPACE = "262144"
+IMAGE_ROOTFS_EXTRA_SPACE = "131072"


### PR DESCRIPTION
This patch reduces the rootfs so that there is only about 32MB of free space.

With this patch I think we can finally close https://github.com/AsteroidOS/meta-asteroid/issues/16