### PR TITLE
asteroid-image: Generate package index when creating image.

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -16,3 +16,12 @@ EXTRA_USERS_PARAMS = "groupadd system; \
 
 IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_ROOTFS_EXTRA_SPACE = "262144"
+
+python do_package_index () {
+    from oe.rootfs import generate_index_files
+    generate_index_files(d)
+}
+do_package_index[dirs] = "${TOPDIR}"
+do_package_index[umask] = "022"
+do_package_index[file-checksums] += "${POSTINST_INTERCEPT_CHECKSUMS}"
+addtask do_package_index before do_rootfs


### PR DESCRIPTION
As per https://github.com/openembedded/openembedded-core/commit/c7c5f4065c102fde4e11d138fb0b6e25bffe0379#diff-c5130ef47a8c44ef3dc72358e5dd3ed0L1134 the deploy directory for the package index has been changed to a different directory. Using `bitbake package-index` we can manually trigger a package index build for the deploy directory.

This patch adds a copy of the function that is used by `bitbake package-index` just before it builds the rootfs.

This should fix https://github.com/AsteroidOS/meta-bass-hybris/issues/10