### PR TITLE
asteroid-image: package-index depends on opkg-make-index.

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -21,6 +21,7 @@ python do_package_index () {
     from oe.rootfs import generate_index_files
     generate_index_files(d)
 }
+do_package_index[depends] += "${PACKAGEINDEXDEPS}"
 do_package_index[dirs] = "${TOPDIR}"
 do_package_index[umask] = "022"
 do_package_index[file-checksums] += "${POSTINST_INTERCEPT_CHECKSUMS}"


### PR DESCRIPTION
In a previous commit I provided a fix for the repository not being generated. However, it seems that I forgot to include the dependency for the `opkg-make-index` tool.
This results in errors during a clean build.

This fixes https://github.com/AsteroidOS/asteroid/issues/115