### PR TITLE
linux: Add kernel modules to image.

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -5,7 +5,7 @@ LICENSE = "GPL-2.0"
 IMAGE_FEATURES += "package-management debug-tweaks"
 
 IMAGE_INSTALL += " \
-base-files base-passwd systemd busybox iproute2 connman pam-plugin-loginuid bluez5 pulseaudio-server openssh-sshd openssh-sftp-server openssh-scp statefs dsme mce ngfd timed sensorfw android-init resize-rootfs mapplauncherd-booster-qtcomponents usb-moded ofono \
+kernel-modules base-files base-passwd systemd busybox iproute2 connman pam-plugin-loginuid bluez5 pulseaudio-server openssh-sshd openssh-sftp-server openssh-scp statefs dsme mce ngfd timed sensorfw android-init resize-rootfs mapplauncherd-booster-qtcomponents usb-moded ofono \
 supported-languages asteroid-launcher asteroid-calculator asteroid-calendar asteroid-stopwatch asteroid-settings asteroid-timer asteroid-alarmclock asteroid-weather asteroid-music asteroid-btsyncd asteroid-flashlight"
 
 EXTRA_USERS_PARAMS = "groupadd system; \


### PR DESCRIPTION
Some ports require kernel modules to be packaged with rootfs.
This patch fixes sensors not working on sparrow.
Big thanks to @hummlbach for providing help in fixing this issue!

This patch was originally applied to the meta-sparrow platform only. This seems general enough to be included for all platforms. Other platforms swift, anthias and tetra also use kernel modules which likely aren't included in the final image. This may fixes issues on those platforms too, though not tested!

Close this PR if it turns out that this PR has negative effects on other platforms.