### PR TITLE
machine: Set default architecture tune to armv7vehf-neon

### DIFF
--- a/conf/machine/include/hybris-watch.inc
+++ b/conf/machine/include/hybris-watch.inc
@@ -15,3 +15,5 @@ IMAGE_FSTYPES += "ext4"
 IMAGE_ROOTFS_ALIGNMENT="4"
 
 IMAGE_INSTALL += "android-tools android-system firmwared"
+
+DEFAULTTUNE = "armv7vehf-neon"


### PR DESCRIPTION
https://github.com/openembedded/openembedded-core/blob/warrior/meta/conf/machine/include/tune-cortexa7.inc#L1 has the default tune: armv7vethf-neon

This results in either tune `armv7vehf-neon` or `armv7vet2hf-neon` based on https://github.com/openembedded/openembedded-core/blob/warrior/meta/conf/machine/include/arm/arch-armv7ve.inc#L84.

I guess it select one of the tunes based on which platform is build first.

Setting the default tune to `armv7vehf-neon` should result in only `armv7vehf-neon`.

This should fix opkg not working with the current nightly build.

Note: My system is still building (has to build everything again :/). Will report when tested.