### PR TITLE
qt5-qpa-hwcomposer-plugin & timed: Add support for ambient mode.

### DIFF
--- a/recipes-nemomobile/lipstick/lipstick_git.bb
+++ b/recipes-nemomobile/lipstick/lipstick_git.bb
@@ -17,7 +17,7 @@ S = "${WORKDIR}/git"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-DEPENDS += "qtbase qtsensors qtdeclarative qtwayland mlite dbus dbus-glib libresourceqt qtsystems libngf-qt statefs-qt mce usb-moded-qt5 systemd wayland nemo-keepalive qttools-native"
+DEPENDS += "timed qtbase qtsensors qtdeclarative qtwayland mlite dbus dbus-glib libresourceqt qtsystems libngf-qt statefs-qt mce usb-moded-qt5 systemd wayland nemo-keepalive qttools-native"
 RDEPENDS_${PN} += "${PN}-locale"
 
 inherit qmake5

--- a/recipes-nemomobile/timed/timed/0002-Add-wakeup-event-for-use-with-ambient-mode.patch
+++ b/recipes-nemomobile/timed/timed/0002-Add-wakeup-event-for-use-with-ambient-mode.patch
@@ -1,0 +1,129 @@
+From 28c579dc30a7e5499d68a128ec479f9c064c1dd3 Mon Sep 17 00:00:00 2001
+From: MagneFire <IDaNLContact@gmail.com>
+Date: Thu, 16 Jul 2020 22:51:52 +0200
+Subject: [PATCH] Add wakeup event for use with ambient mode. It seems like
+ there is no easy way to get a callback from when an event occurs. The only
+ way is using voland. Which, on AsteroidOS, is used by the alarmclock app. So
+ scheduling an event for use with ambient mode would actually show the
+ alarmclock dialog (and update the screen). This is due to alarmclock using a
+ D-Bus (systemd) service that triggers on any voland signal. I don't think
+ there is a way to filter these events with systemd. Another thing that may be
+ used is the `next_bootup_event` event. But this is not a reliable source,
+ because alarmclock events also cause this signal, can cause multiple triggers
+ at irregular intervals.
+
+Somehow we need to update the screen without triggering the alarmclock alarm dialog.
+The most straightforward way to do this is by adding a special `wakeup` type event, that doesn't trigger the voland event, but instead a new event.
+---
+ src/server/adaptor.h   |  1 +
+ src/server/machine.cpp |  1 +
+ src/server/machine.h   |  1 +
+ src/server/state.cpp   | 17 +++++++++++++++--
+ src/server/state.h     |  1 +
+ src/server/timed.cpp   |  1 +
+ src/server/timed.h     |  1 +
+ 7 files changed, 21 insertions(+), 2 deletions(-)
+
+diff --git a/src/server/adaptor.h b/src/server/adaptor.h
+index 7c28921..f7a6491 100644
+--- a/src/server/adaptor.h
++++ b/src/server/adaptor.h
+@@ -80,6 +80,7 @@ signals:
+   void settings_changed_1(bool) ;
+   void next_bootup_event(int next_boot_event, int next_non_boot_event);
+   void alarm_triggers_changed(Maemo::Timed::Event::Triggers);
++  void wakeup_event();
+ 
+ public slots:
+ 
+diff --git a/src/server/machine.cpp b/src/server/machine.cpp
+index 6977fb0..dee03cf 100644
+--- a/src/server/machine.cpp
++++ b/src/server/machine.cpp
+@@ -116,6 +116,7 @@ machine_t::machine_t(const Timed *daemon) : timed(daemon)
+   state_armed->open() ;
+ 
+   QObject::connect(state_dlg_wait, SIGNAL(voland_needed()), this, SIGNAL(voland_needed())) ;
++  QObject::connect(state_dlg_wait, SIGNAL(wakeup_event()), this, SIGNAL(wakeup_event())) ;
+ 
+   QObject::connect(state_dlg_wait, SIGNAL(closed()), state_dlg_requ, SLOT(open())) ;
+   QObject::connect(state_dlg_wait, SIGNAL(closed()), state_dlg_user, SLOT(open())) ;
+diff --git a/src/server/machine.h b/src/server/machine.h
+index de0098f..314aba7 100644
+--- a/src/server/machine.h
++++ b/src/server/machine.h
+@@ -101,6 +101,7 @@ Q_SIGNALS:
+   void queue_to_be_saved() ;
+   void voland_needed() ;
+   void next_bootup_event(int, int);
++  void wakeup_event();
+   void child_created(unsigned, int) ;
+   void alarm_present(bool present);
+   void alarm_trigger(QMap<QString, QVariant> triggers);
+diff --git a/src/server/state.cpp b/src/server/state.cpp
+index 02a7d74..f840a74 100644
+--- a/src/server/state.cpp
++++ b/src/server/state.cpp
+@@ -738,8 +738,21 @@ void state_aborted_t::enter(event_t *e)
+ void state_dlg_wait_t::enter(event_t *e)
+ {
+   e->flags |= EventFlags::In_Dialog ;
+-  if (not is_open)
+-    emit voland_needed() ;
++  for(attribute_t::const_iterator at=e->attr.txt.begin(); at!=e->attr.txt.end(); at++)
++  {
++    QString key = string_std_to_q(at->first) ;
++    QString val = string_std_to_q(at->second) ;
++    if (key == "type") {
++      if (val == "wakeup") {
++        machine->state_served->go_to(e);
++        emit wakeup_event();
++      } else {
++        if (not is_open)
++          emit voland_needed();
++      }
++      break;
++    }
++  }
+   abstract_gate_state_t::enter(e) ;
+ }
+ 
+diff --git a/src/server/state.h b/src/server/state.h
+index 92046e5..0e84ccb 100644
+--- a/src/server/state.h
++++ b/src/server/state.h
+@@ -314,6 +314,7 @@ public:
+   uint32_t cluster_bits() { return EventFlags::Cluster_Dialog ; }
+ Q_SIGNALS:
+   void voland_needed() ;
++  void wakeup_event();
+ private:
+   Q_OBJECT ;
+ } ;
+diff --git a/src/server/timed.cpp b/src/server/timed.cpp
+index 1d1179a..aa386d0 100644
+--- a/src/server/timed.cpp
++++ b/src/server/timed.cpp
+@@ -316,6 +316,7 @@ void Timed::init_create_event_machine()
+ 
+   // Forward signal from am to DBUS via com_nokia_time DBUS adaptor
+   QObject::connect(am, SIGNAL(next_bootup_event(int,int)), this, SIGNAL(next_bootup_event(int,int)));
++  QObject::connect(am, SIGNAL(wakeup_event()), this, SIGNAL(wakeup_event()));
+   voland_watcher = NULL ;
+   QObject::connect(this, SIGNAL(voland_registered()), am, SIGNAL(voland_registered())) ;
+   QObject::connect(this, SIGNAL(voland_unregistered()), am, SIGNAL(voland_unregistered())) ;
+diff --git a/src/server/timed.h b/src/server/timed.h
+index e7cb2a7..2bdd62b 100644
+--- a/src/server/timed.h
++++ b/src/server/timed.h
+@@ -165,6 +165,7 @@ Q_SIGNALS:
+   void settings_changed(const Maemo::Timed::WallClock::Info &, bool system_time) ;
+   void next_bootup_event(int next_boot_event, int next_non_boot_event);
+   void alarm_triggers_changed(Maemo::Timed::Event::Triggers);
++  void wakeup_event();
+   // void settings_changed_1(bool system_time) ;
+ public:
+   Timed(int ac, char **av) ;
+-- 
+2.28.0
+

--- a/recipes-nemomobile/timed/timed_git.bb
+++ b/recipes-nemomobile/timed/timed_git.bb
@@ -5,6 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://git.merproject.org/mer-core/timed.git;protocol=https \
     file://0001-Fixes-build.patch \
+    file://0002-Add-wakeup-event-for-use-with-ambient-mode.patch \
     file://timed-qt5.conf \
     file://timed-qt5.service"
 SRCREV = "c7c1380fcc72390d59f1dc3e01b0cff29207f293"

--- a/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0006-Add-ambient-mode-display-support.patch
+++ b/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0006-Add-ambient-mode-display-support.patch
@@ -1,0 +1,187 @@
+From 1c568ba41538408449a77e58357d16bbbb197bf4 Mon Sep 17 00:00:00 2001
+From: MagneFire <IDaNLContact@gmail.com>
+Date: Mon, 6 Jul 2020 22:03:51 +0200
+Subject: [PATCH] Add ambient mode display support. Add ability to keep the
+ screen on while in deep sleep mode. This is achieved by setting the power
+ mode to HWC_POWER_MODE_DOZE_SUSPEND.
+
+https://android.googlesource.com/platform/hardware/libhardware/+/refs/heads/master/include/hardware/hwcomposer_defs.h#299 implies that the power mode needs to be changed to update the screen, but according to several tests (on sturgeon and smelt) this seems to be not necessary. Swapping the buffer while the screen is off still appears to update the screen.
+---
+ hwcomposer/hwcomposer_backend.h       |  2 ++
+ hwcomposer/hwcomposer_backend_v11.cpp | 33 +++++++++++++++++++++++++--
+ hwcomposer/hwcomposer_backend_v11.h   |  3 +++
+ hwcomposer/hwcomposer_context.cpp     | 15 +++++++++++-
+ hwcomposer/hwcomposer_context.h       |  3 +++
+ hwcomposer/qeglfsintegration.cpp      |  6 +++++
+ 6 files changed, 59 insertions(+), 3 deletions(-)
+
+diff --git a/hwcomposer/hwcomposer_backend.h b/hwcomposer/hwcomposer_backend.h
+index 5c579aa..fffc3d8 100644
+--- a/hwcomposer/hwcomposer_backend.h
++++ b/hwcomposer/hwcomposer_backend.h
+@@ -106,6 +106,8 @@ public:
+     virtual EGLNativeWindowType createWindow(int width, int height) = 0;
+     virtual void destroyWindow(EGLNativeWindowType window) = 0;
+     virtual void swap(EGLNativeDisplayType display, EGLSurface surface) = 0;
++    virtual bool ambientModeSupport() {return false;}
++    virtual void ambientModeEnabled(bool enable) {Q_UNUSED(enable);}
+     virtual void sleepDisplay(bool sleep) = 0;
+     virtual float refreshRate() = 0;
+ 
+diff --git a/hwcomposer/hwcomposer_backend_v11.cpp b/hwcomposer/hwcomposer_backend_v11.cpp
+index 933fa17..353a144 100644
+--- a/hwcomposer/hwcomposer_backend_v11.cpp
++++ b/hwcomposer/hwcomposer_backend_v11.cpp
+@@ -320,6 +320,27 @@ HwComposerBackend_v11::swap(EGLNativeDisplayType display, EGLSurface surface)
+ #endif
+ }
+ 
++bool HwComposerBackend_v11::ambientModeSupport()
++{
++#ifdef HWC_DEVICE_API_VERSION_1_4
++        if (hwc_version == HWC_DEVICE_API_VERSION_1_4) {
++            return true;
++        } else
++#endif
++#ifdef HWC_DEVICE_API_VERSION_1_5
++        if (hwc_version == HWC_DEVICE_API_VERSION_1_5) {
++            return true;
++        } else
++#endif
++            return false;
++}
++
++void HwComposerBackend_v11::ambientModeEnabled(bool enable)
++{
++    if (ambientModeSupport()) {
++        m_ambientMode = enable;
++    }
++}
+ void
+ HwComposerBackend_v11::sleepDisplay(bool sleep)
+ {
+@@ -333,12 +354,20 @@ HwComposerBackend_v11::sleepDisplay(bool sleep)
+ 
+ #ifdef HWC_DEVICE_API_VERSION_1_4
+         if (hwc_version == HWC_DEVICE_API_VERSION_1_4) {
+-            HWC_PLUGIN_EXPECT_ZERO(hwc_device->setPowerMode(hwc_device, 0, HWC_POWER_MODE_OFF));
++            if (m_ambientMode) {
++                HWC_PLUGIN_EXPECT_ZERO(hwc_device->setPowerMode(hwc_device, 0, HWC_POWER_MODE_DOZE_SUSPEND));
++            } else {
++                HWC_PLUGIN_EXPECT_ZERO(hwc_device->setPowerMode(hwc_device, 0, HWC_POWER_MODE_OFF));
++            }
+         } else
+ #endif
+ #ifdef HWC_DEVICE_API_VERSION_1_5
+         if (hwc_version == HWC_DEVICE_API_VERSION_1_5) {
+-            HWC_PLUGIN_EXPECT_ZERO(hwc_device->setPowerMode(hwc_device, 0, HWC_POWER_MODE_OFF));
++            if (m_ambientMode) {
++                HWC_PLUGIN_EXPECT_ZERO(hwc_device->setPowerMode(hwc_device, 0, HWC_POWER_MODE_DOZE_SUSPEND));
++            } else {
++                HWC_PLUGIN_EXPECT_ZERO(hwc_device->setPowerMode(hwc_device, 0, HWC_POWER_MODE_OFF));
++            }
+         } else
+ #endif
+             HWC_PLUGIN_EXPECT_ZERO(hwc_device->blank(hwc_device, 0, 1));
+diff --git a/hwcomposer/hwcomposer_backend_v11.h b/hwcomposer/hwcomposer_backend_v11.h
+index 98561de..9a623de 100644
+--- a/hwcomposer/hwcomposer_backend_v11.h
++++ b/hwcomposer/hwcomposer_backend_v11.h
+@@ -63,6 +63,8 @@ public:
+     virtual EGLNativeWindowType createWindow(int width, int height);
+     virtual void destroyWindow(EGLNativeWindowType window);
+     virtual void swap(EGLNativeDisplayType display, EGLSurface surface);
++    virtual bool ambientModeSupport() Q_DECL_OVERRIDE;
++    virtual void ambientModeEnabled(bool enable) Q_DECL_OVERRIDE;
+     virtual void sleepDisplay(bool sleep);
+     virtual float refreshRate();
+ 
+@@ -79,6 +81,7 @@ private:
+     uint32_t hwc_version;
+     int num_displays;
+ 
++    bool m_ambientMode;
+     bool m_displayOff;
+     QBasicTimer m_deliverUpdateTimeout;
+     QBasicTimer m_vsyncTimeout;
+diff --git a/hwcomposer/hwcomposer_context.cpp b/hwcomposer/hwcomposer_context.cpp
+index 15ce986..74435a7 100644
+--- a/hwcomposer/hwcomposer_context.cpp
++++ b/hwcomposer/hwcomposer_context.cpp
+@@ -74,6 +74,7 @@ HwComposerContext::HwComposerContext()
+     : info(new HwComposerScreenInfo())
+     , backend(NULL)
+     , display_off(false)
++    , ambientMode(false)
+     , window_created(false)
+     , fps(0)
+ {
+@@ -161,7 +162,7 @@ void HwComposerContext::destroyNativeWindow(EGLNativeWindowType window)
+ 
+ void HwComposerContext::swapToWindow(QEglFSContext *context, QPlatformSurface *surface)
+ {
+-    if (display_off) {
++    if (display_off && !ambientMode) {
+         qWarning("Swap requested while display is off");
+         return;
+     }
+@@ -170,6 +171,18 @@ void HwComposerContext::swapToWindow(QEglFSContext *context, QPlatformSurface *s
+     EGLSurface egl_surface = context->eglSurfaceForPlatformSurface(surface);
+     return backend->swap(egl_display, egl_surface);
+ }
++bool HwComposerContext::ambientModeSupport()
++{
++    return backend->ambientModeSupport();
++}
++
++void HwComposerContext::ambientModeEnabled(bool enable)
++{
++    if (!ambientModeSupport()) return;
++
++    ambientMode = enable;
++    backend->ambientModeEnabled(enable);
++}
+ 
+ void HwComposerContext::sleepDisplay(bool sleep)
+ {
+diff --git a/hwcomposer/hwcomposer_context.h b/hwcomposer/hwcomposer_context.h
+index 1d78a2c..5044a35 100644
+--- a/hwcomposer/hwcomposer_context.h
++++ b/hwcomposer/hwcomposer_context.h
+@@ -79,6 +79,8 @@ public:
+ 
+     void swapToWindow(QEglFSContext *context, QPlatformSurface *surface);
+ 
++    bool ambientModeSupport();
++    void ambientModeEnabled(bool enable);
+     void sleepDisplay(bool sleep);
+     qreal refreshRate() const;
+ 
+@@ -88,6 +90,7 @@ private:
+     HwComposerScreenInfo *info;
+     HwComposerBackend *backend;
+     bool display_off;
++    bool ambientMode;
+     bool window_created;
+     qreal fps;
+ };
+diff --git a/hwcomposer/qeglfsintegration.cpp b/hwcomposer/qeglfsintegration.cpp
+index 112bfd8..811a217 100644
+--- a/hwcomposer/qeglfsintegration.cpp
++++ b/hwcomposer/qeglfsintegration.cpp
+@@ -195,6 +195,12 @@ void *QEglFSIntegration::nativeResourceForIntegration(const QByteArray &resource
+ 
+     if (lowerCaseResource == "egldisplay") {
+         return static_cast<QEglFSScreen *>(mScreen)->display();
++    } else if (lowerCaseResource == "ambientsupported") {
++        return reinterpret_cast<void *>(mHwc->ambientModeSupport());
++    } else if (lowerCaseResource == "ambientenable") {
++        mHwc->ambientModeEnabled(true);
++    } else if (lowerCaseResource == "ambientdisable") {
++        mHwc->ambientModeEnabled(false);
+     } else if (lowerCaseResource == "displayoff") {
+         // Called from lipstick to turn off the display (src/homeapplication.cpp)
+         mHwc->sleepDisplay(true);
+-- 
+2.28.0
+

--- a/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
+++ b/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
@@ -15,7 +15,9 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 SRC_URI = "git://github.com/mer-hybris/qt5-qpa-hwcomposer-plugin;protocol=https \
            file://0003-Fix-build-with-Qt-5.9.patch;striplevel=2 \
-           file://0005-hwcomposer_backend_v11-fix-compatibility-with-qtbase.patch;striplevel=2"
+           file://0005-hwcomposer_backend_v11-fix-compatibility-with-qtbase.patch;striplevel=2 \
+           file://0006-Add-ambient-mode-display-support.patch;striplevel=2 \
+"
 S = "${WORKDIR}/git/hwcomposer"
 SRCREV = "bb95d09b893761c25409363e15f7048739c436ba"
 


### PR DESCRIPTION
The PR adds support for an Always on display functionality. Because qt5-qpa-hwcomposer-plugin & timed don't have a repo in the AsteroidOS organization. It may be easier to look in the separate commits for review:
https://github.com/MagneFire/qt5-qpa-hwcomposer-plugin/commit/1c568ba41538408449a77e58357d16bbbb197bf4
https://github.com/MagneFire/timed/commit/28c579dc30a7e5499d68a128ec479f9c064c1dd3

Other PRs that are also needed are:
- https://github.com/AsteroidOS/lipstick/pull/9
- https://github.com/AsteroidOS/asteroid-launcher/pull/42
- https://github.com/AsteroidOS/mce/pull/4
- https://github.com/AsteroidOS/asteroid-settings/pull/25

And for devices I have tuned the ambient mode brightness setting for sturgeon and smelt:
- https://github.com/AsteroidOS/meta-sturgeon-hybris/pull/11
- https://github.com/AsteroidOS/meta-smelt-hybris/pull/12


Here is also an overview of what the watchfaces look like in ambient mode:
![Screenshot_20200801_202406](https://user-images.githubusercontent.com/7857908/89129942-ad748680-d501-11ea-8875-8c3fbd018e71.jpg)
![Screenshot_20200801_202350](https://user-images.githubusercontent.com/7857908/89129943-b2d1d100-d501-11ea-98c2-8ffd9081bffb.jpg)
![Screenshot_20200801_202331](https://user-images.githubusercontent.com/7857908/89129944-b49b9480-d501-11ea-83b1-288ca86e104b.jpg)
![Screenshot_20200801_202311](https://user-images.githubusercontent.com/7857908/89129945-b6fdee80-d501-11ea-9914-46623e16bac3.jpg)
![Screenshot_20200801_202253](https://user-images.githubusercontent.com/7857908/89129946-b8c7b200-d501-11ea-917b-488f21b1fef5.jpg)
![Screenshot_20200801_202236](https://user-images.githubusercontent.com/7857908/89129950-bb2a0c00-d501-11ea-98da-bccd369f1d09.jpg)
![Screenshot_20200801_202217](https://user-images.githubusercontent.com/7857908/89129953-be24fc80-d501-11ea-99c8-ba8b8d5e7c46.jpg)
![Screenshot_20200801_202158](https://user-images.githubusercontent.com/7857908/89129956-bf562980-d501-11ea-842a-67d155ecb401.jpg)
![Screenshot_20200801_202139](https://user-images.githubusercontent.com/7857908/89129961-c2511a00-d501-11ea-86ff-b4e9de0d8be4.jpg)
![Screenshot_20200801_202121](https://user-images.githubusercontent.com/7857908/89129963-c54c0a80-d501-11ea-953e-8ef8e2af89f8.jpg)
![Screenshot_20200801_202102](https://user-images.githubusercontent.com/7857908/89129966-c7ae6480-d501-11ea-8624-324a5d3e8075.jpg)


Of course this finally fixes https://github.com/AsteroidOS/asteroid/issues/58