### PR TITLE
This allows machines to add a `init.machine` script to initramfs

### DIFF
--- a/recipes-core/initrdscripts/initramfs-scripts-android/init.sh
+++ b/recipes-core/initrdscripts/initramfs-scripts-android/init.sh
@@ -93,6 +93,11 @@ if [ -e $ANDROID_MEDIA_DIR/asteroidos.ext4 ] ; then
     [ $? -ne 0 ] || BOOT_DIR="/loop"
 fi
 
+if [ -x /init.machine ]; then
+    info "Run machine specific init"
+    /init.machine $BOOT_DIR > /dev/ttyprintk
+fi
+
 setup_devtmpfs $BOOT_DIR
 
 info "Move the /proc and /sys filesystems..."


### PR DESCRIPTION
This is used for lenok (and will probably be used for others) to mount the `persist` filesystem and restart the wifi controller, loading the correct MAC address before the real system starts. Can be used for a lot of machine specific things, though.

Everything `init.machine` prints on `stdout` is redirected to `/dev/ttyprintk` - the kernel log.