### PR TITLE
qtdbusextended: Fix setting mpris properties.

### DIFF
--- a/recipes-nemomobile/qtdbusextended/qtdbusextended/0001-Use-variant-when-setting-properties.patch
+++ b/recipes-nemomobile/qtdbusextended/qtdbusextended/0001-Use-variant-when-setting-properties.patch
@@ -1,0 +1,30 @@
+From 78231f00b786e8da20a49da2861285ae440b0bf8 Mon Sep 17 00:00:00 2001
+From: MagneFire <IDaNLContact@gmail.com>
+Date: Mon, 31 Aug 2020 19:03:58 +0200
+Subject: [PATCH] Use variant when setting properties.
+ org.freedesktop.DBus.Properties.Set expects a variant containing a type and
+ value(variant:double:0.4). Previously it would just send the type and value
+ (double:0.4). This would result in the following error:   string "No such
+ method 'Set' in interface 'org.freedesktop.DBus.Properties' at object path
+ '/org/mpris/MediaPlayer2' (signature 'ssd')"
+
+---
+ src/dbusextendedabstractinterface.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/dbusextendedabstractinterface.cpp b/src/dbusextendedabstractinterface.cpp
+index 935278e..9348ab8 100644
+--- a/src/dbusextendedabstractinterface.cpp
++++ b/src/dbusextendedabstractinterface.cpp
+@@ -243,7 +243,7 @@ void DBusExtendedAbstractInterface::internalPropSet(const char *propname, const
+             return;
+         }
+ 
+-        asyncSetProperty(propname, QVariant(metaProperty.type(), propertyPtr));
++        asyncSetProperty(propname, QVariant::fromValue(QDBusVariant(QVariant(metaProperty.type(), propertyPtr))));
+     }
+ }
+ 
+-- 
+2.28.0
+

--- a/recipes-nemomobile/qtdbusextended/qtdbusextended_git.bb
+++ b/recipes-nemomobile/qtdbusextended/qtdbusextended_git.bb
@@ -3,7 +3,9 @@ HOMEPAGE = "https://github.com/nemomobile/qtdbusextended"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=9851ce31b8dbc090eecd6cec46a8bf62"
 
-SRC_URI = "git://github.com/nemomobile/qtdbusextended.git;protocol=https"
+SRC_URI = "git://github.com/nemomobile/qtdbusextended.git;protocol=https \
+    file://0001-Use-variant-when-setting-properties.patch
+"
 SRCREV = "34971431233dc408553245001148d34a09836df1"
 PR = "r1"
 PV = "+git${SRCPV}"


### PR DESCRIPTION
When setting the volume, shuffle, loop status it would fail with:
error time=1598646695.682396 sender=:1.3 -> destination=:1.12 error_name=org.freedesktop.DBus.Error.UnknownMethod reply_serial=69
    string "No such method 'Set' in interface 'org.freedesktop.DBus.Properties' at object path '/org/mpris/MediaPlayer2' (signature 'ssd')"

This is due to qtdbusextended setting the properties using the type and value immediately (double:0.4), while the format variant:type:value(varient:double:0.4) is expected.

This commit fixes this issue by wrapping the type and value in a variant.


It took me quite some time to figure out what was going wrong :cry: 

Some useful things that may be helpful for others are:
- Use dbus-monitor, to look at all dbus messages.
- Use the `dbus-send --print-reply --dest=org.mpris.MediaPlayer2.asteroid-btsyncd /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Set string:org.mpris.MediaPlayer2.Player string:Volume variant:double:0.4` command to set the volume from the console.
- `dbus-send --print-reply --dest=org.mpris.MediaPlayer2.asteroid-btsyncd /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:org.mpris.MediaPlayer2.Player string:Volume` Gets the current volume.
- `dbus-send --print-reply --dest=org.mpris.MediaPlayer2.asteroid-btsyncd /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.PlayPause` play/pause playback.
- `dbus-send --print-reply --dest=org.mpris.MediaPlayer2.asteroid-btsyncd /org/mpris/MediaPlayer2 org.freedesktop.DBus.Introspectable.Introspect` Get list of all methods/properties.