### PR TITLE
qtdbusextended: Fix recipe parse error.

### DIFF
--- a/recipes-nemomobile/qtdbusextended/qtdbusextended_git.bb
+++ b/recipes-nemomobile/qtdbusextended/qtdbusextended_git.bb
@@ -4,7 +4,7 @@ LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=9851ce31b8dbc090eecd6cec46a8bf62"
 
 SRC_URI = "git://github.com/nemomobile/qtdbusextended.git;protocol=https \
-    file://0001-Use-variant-when-setting-properties.patch
+    file://0001-Use-variant-when-setting-properties.patch \
 "
 SRCREV = "34971431233dc408553245001148d34a09836df1"
 PR = "r1"


### PR DESCRIPTION
Oops, somehow it was working on my machine.

Anyway, adding a backslash fixes the recipe parse error.