### PR TITLE
qt5-qpa-hwcomposer-plugin: Use PowerHAL to setInteractive based on display state.

### DIFF
--- a/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0007-backend-setInteractive-based-on-display-state.patch
+++ b/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0007-backend-setInteractive-based-on-display-state.patch
@@ -1,0 +1,121 @@
+From 6919d73eb5f88eff13b63c5e69785db94f6cfba8 Mon Sep 17 00:00:00 2001
+From: MagneFire <IDaNLContact@gmail.com>
+Date: Fri, 18 Sep 2020 20:43:41 +0200
+Subject: [PATCH] backend: setInteractive based on display state. Load the
+ PowerHAL to setInteractive state based on sleepDisplay.
+
+This fixes ambient display on some platforms.
+---
+ hwcomposer/hwcomposer_backend.cpp     | 8 +++++++-
+ hwcomposer/hwcomposer_backend.h       | 2 ++
+ hwcomposer/hwcomposer_backend_v11.cpp | 9 ++++++++-
+ hwcomposer/hwcomposer_backend_v11.h   | 3 ++-
+ 4 files changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/hwcomposer/hwcomposer_backend.cpp b/hwcomposer/hwcomposer_backend.cpp
+index d2ed310..bf8e5e1 100644
+--- a/hwcomposer/hwcomposer_backend.cpp
++++ b/hwcomposer/hwcomposer_backend.cpp
+@@ -62,6 +62,7 @@ HwComposerBackend::create()
+ {
+     hw_module_t *hwc_module = NULL;
+     hw_device_t *hwc_device = NULL;
++    power_module_t *pwr_module = NULL;
+ 
+     // Some implementations insist on having the framebuffer module opened before loading
+     // the hardware composer one. Therefor we rely on using the fbdev HYBRIS_EGLPLATFORM
+@@ -70,6 +71,11 @@ HwComposerBackend::create()
+ 	    eglGetDisplay(EGL_DEFAULT_DISPLAY);
+     }
+ 
++    // Open power module for setting interactive state based on screen on/off.
++    HWC_PLUGIN_ASSERT_ZERO(hw_get_module(POWER_HARDWARE_MODULE_ID, (const hw_module_t **)(&pwr_module)));
++
++    pwr_module->init(pwr_module);
++
+     // Open hardware composer
+     HWC_PLUGIN_ASSERT_ZERO(hw_get_module(HWC_HARDWARE_MODULE_ID, (const hw_module_t **)(&hwc_module)));
+ 
+@@ -133,7 +139,7 @@ HwComposerBackend::create()
+ #endif
+             // HWC_NUM_DISPLAY_TYPES is the actual size of the array, otherwise
+             // underrun/overruns happen
+-            return new HwComposerBackend_v11(hwc_module, hwc_device, HWC_NUM_DISPLAY_TYPES);
++            return new HwComposerBackend_v11(hwc_module, hwc_device, pwr_module, HWC_NUM_DISPLAY_TYPES);
+             break;
+ #endif /* HWC_PLUGIN_HAVE_HWCOMPOSER1_API */
+         default:
+diff --git a/hwcomposer/hwcomposer_backend.h b/hwcomposer/hwcomposer_backend.h
+index fffc3d8..84c59f8 100644
+--- a/hwcomposer/hwcomposer_backend.h
++++ b/hwcomposer/hwcomposer_backend.h
+@@ -48,6 +48,7 @@
+ #include <android-config.h>
+ #include <hardware/hardware.h>
+ #include <hardware/hwcomposer.h>
++#include <hardware/power.h>
+ 
+ #include <EGL/egl.h>
+ #include <EGL/eglext.h>
+@@ -118,6 +119,7 @@ protected:
+     virtual ~HwComposerBackend();
+ 
+     hw_module_t *hwc_module;
++    power_module_t *pwr_module;
+ };
+ 
+ #endif /* HWCOMPOSER_BACKEND_H */
+diff --git a/hwcomposer/hwcomposer_backend_v11.cpp b/hwcomposer/hwcomposer_backend_v11.cpp
+index 353a144..fad8e62 100644
+--- a/hwcomposer/hwcomposer_backend_v11.cpp
++++ b/hwcomposer/hwcomposer_backend_v11.cpp
+@@ -152,9 +152,10 @@ void HWComposer::present(HWComposerNativeWindowBuffer *buffer)
+     }
+ }
+ 
+-HwComposerBackend_v11::HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, int num_displays)
++HwComposerBackend_v11::HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, power_module_t *pw_device, int num_displays)
+     : HwComposerBackend(hwc_module)
+     , hwc_device((hwc_composer_device_1_t *)hw_device)
++    , pwr_device(pw_device)
+     , hwc_list(NULL)
+     , hwc_mList(NULL)
+     , num_displays(num_displays)
+@@ -371,7 +372,13 @@ HwComposerBackend_v11::sleepDisplay(bool sleep)
+         } else
+ #endif
+             HWC_PLUGIN_EXPECT_ZERO(hwc_device->blank(hwc_device, 0, 1));
++
++        // Enter non-interactive state after turning off the screen.
++        pwr_device->setInteractive(pwr_device, false);
+     } else {
++        // Enter interactive state prior to turning on the screen.
++        pwr_device->setInteractive(pwr_device, true);
++
+ #ifdef HWC_DEVICE_API_VERSION_1_4
+         if (hwc_version == HWC_DEVICE_API_VERSION_1_4) {
+             HWC_PLUGIN_EXPECT_ZERO(hwc_device->setPowerMode(hwc_device, 0, HWC_POWER_MODE_NORMAL));
+diff --git a/hwcomposer/hwcomposer_backend_v11.h b/hwcomposer/hwcomposer_backend_v11.h
+index 9a623de..4961e74 100644
+--- a/hwcomposer/hwcomposer_backend_v11.h
++++ b/hwcomposer/hwcomposer_backend_v11.h
+@@ -56,7 +56,7 @@ class QWindow;
+ 
+ class HwComposerBackend_v11 : public QObject, public HwComposerBackend {
+ public:
+-    HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, int num_displays);
++    HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, power_module_t *pw_device, int num_displays);
+     virtual ~HwComposerBackend_v11();
+ 
+     virtual EGLNativeDisplayType display();
+@@ -76,6 +76,7 @@ public:
+ 
+ private:
+     hwc_composer_device_1_t *hwc_device;
++    power_module_t *pwr_device;
+     hwc_display_contents_1_t *hwc_list;
+     hwc_display_contents_1_t **hwc_mList;
+     uint32_t hwc_version;
+-- 
+2.28.0
+

--- a/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
+++ b/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
@@ -17,6 +17,7 @@ SRC_URI = "git://github.com/mer-hybris/qt5-qpa-hwcomposer-plugin;protocol=https 
            file://0003-Fix-build-with-Qt-5.9.patch;striplevel=2 \
            file://0005-hwcomposer_backend_v11-fix-compatibility-with-qtbase.patch;striplevel=2 \
            file://0006-Add-ambient-mode-display-support.patch;striplevel=2 \
+           file://0007-backend-setInteractive-based-on-display-state.patch;striplevel=2 \
 "
 S = "${WORKDIR}/git/hwcomposer"
 SRCREV = "bb95d09b893761c25409363e15f7048739c436ba"


### PR DESCRIPTION
Appears to fix Always-on-Display on some platforms (wren confirmed.).

Huge thanks to @daniellandau for helping fix this issue!