### PR TITLE
qml-asteroid: Use a configuration file for device specific settings.

### DIFF
--- a/recipes-asteroid/asteroid-machine-config/asteroid-machine-config_1.0.bb
+++ b/recipes-asteroid/asteroid-machine-config/asteroid-machine-config_1.0.bb
@@ -1,0 +1,37 @@
+SUMMARY = "Generates a machine specific config file for AsteroidOS"
+LICENSE = "GPLv3"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+python do_generate_config () {
+    machine_vars = {
+        "Display": ["MACHINE_DISPLAY_FLAT_TIRE", "MACHINE_DISPLAY_BORDER_GESTURE_WIDTH", "MACHINE_DISPLAY_ROUND"],
+        "Capabilities": ["MACHINE_HAS_WLAN", "MACHINE_HAS_SPEAKER"]
+    }
+
+    from configparser import ConfigParser
+    config = ConfigParser()
+    config.optionxform=str
+
+    for key in machine_vars:
+        config.add_section(key)
+        for var in machine_vars[key]:
+            v = var[len("MACHINE_"):]
+            if v.startswith(key.upper() + "_"):
+                v = v[len(key.upper() + "_"):]
+            if d.getVar(var) is not None:
+                config.set(key, v, str(d.getVar(var)))
+
+    with open(d.getVar('WORKDIR') + "/machine.conf", "w") as machine_conf:
+        config.write(machine_conf)
+}
+
+do_install_append() {
+    install -d ${D}/etc/asteroid/
+    install -m 644 ${WORKDIR}/machine.conf ${D}/etc/asteroid/machine.conf
+}
+
+addtask do_generate_config before do_install
+
+FILES_${PN} += "/etc/asteroid/"

--- a/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
+++ b/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
@@ -11,33 +11,8 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 inherit qmake5
 
-PACKAGE_ARCH = "${MACHINE_ARCH}"
-
-DEPENDS += "qtdeclarative qtsvg qtvirtualkeyboard mlite mapplauncherd-booster-qtcomponents qtdeclarative-native"
-RDEPENDS_${PN} += "qtsvg-plugins qtvirtualkeyboard asteroid-icons-ion"
-
-do_configure_prepend() {
-    if [ ${MACHINE_DISPLAY_FLAT_TIRE} ]
-    then
-        export EXTRA_QMAKEVARS_PRE="${EXTRA_QMAKEVARS_PRE} DEFINES+=FLAT_TIRE=${MACHINE_DISPLAY_FLAT_TIRE}"
-    fi
-    if [ ${MACHINE_DISPLAY_BORDER_GESTURE_WIDTH} ]
-    then
-        export EXTRA_QMAKEVARS_PRE="${EXTRA_QMAKEVARS_PRE} DEFINES+=BORDER_GESTURE_WIDTH=${MACHINE_DISPLAY_BORDER_GESTURE_WIDTH}"
-    fi
-    if [ ${MACHINE_DISPLAY_ROUND} = "true" ]
-    then
-        export EXTRA_QMAKEVARS_PRE="${EXTRA_QMAKEVARS_PRE} DEFINES+=ROUND_SCREEN"
-    fi
-    if [ ${MACHINE_HAS_WLAN} = "true" ]
-    then
-        export EXTRA_QMAKEVARS_PRE="${EXTRA_QMAKEVARS_PRE} DEFINES+=HAS_WLAN"
-    fi
-    if [ ${MACHINE_HAS_SPEAKER} = "true" ]
-    then
-        export EXTRA_QMAKEVARS_PRE="${EXTRA_QMAKEVARS_PRE} DEFINES+=HAS_SPEAKER"
-    fi
-}
+DEPENDS += "asteroid-machine-config qtdeclarative qtsvg qtvirtualkeyboard mlite mapplauncherd-booster-qtcomponents qtdeclarative-native"
+RDEPENDS_${PN} += "asteroid-machine-config qtsvg-plugins qtvirtualkeyboard asteroid-icons-ion"
 
 FILES_${PN} += "/usr/lib /usr/share/icons/asteroid/"
 FILES_${PN}-dbg += "/usr/lib/qml/org/asteroid/controls/.debug/ /usr/lib/qml/QtQuick/Controls/Styles/Asteroid/.debug/"


### PR DESCRIPTION
Adjust recipe to use a `machine.conf` file when it is provided by a meta-*-hybris layer. Otherwise the defaults are assumed.