### PR TITLE
qt5-qpa-hwcomposer-plugin: Don't crash when PowerHAL doesn't work.

### DIFF
--- a/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0008-backend-Don-t-crash-when-power-HAL-doesn-t-exist.patch
+++ b/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0008-backend-Don-t-crash-when-power-HAL-doesn-t-exist.patch
@@ -1,0 +1,53 @@
+From 91b9bcbfc428d9992e853efbfc6c24b5f8c549bf Mon Sep 17 00:00:00 2001
+From: MagneFire <IDaNLContact@gmail.com>
+Date: Wed, 14 Oct 2020 20:16:28 +0200
+Subject: [PATCH] backend: Don't crash when power HAL doesn't exist.
+
+---
+ hwcomposer/hwcomposer_backend.cpp     | 8 +++++---
+ hwcomposer/hwcomposer_backend_v11.cpp | 8 ++++++--
+ 2 files changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/hwcomposer/hwcomposer_backend.cpp b/hwcomposer/hwcomposer_backend.cpp
+index bf8e5e1..2caf73f 100644
+--- a/hwcomposer/hwcomposer_backend.cpp
++++ b/hwcomposer/hwcomposer_backend.cpp
+@@ -72,9 +72,11 @@ HwComposerBackend::create()
+     }
+ 
+     // Open power module for setting interactive state based on screen on/off.
+-    HWC_PLUGIN_ASSERT_ZERO(hw_get_module(POWER_HARDWARE_MODULE_ID, (const hw_module_t **)(&pwr_module)));
+-
+-    pwr_module->init(pwr_module);
++    if (!hw_get_module(POWER_HARDWARE_MODULE_ID, (const hw_module_t **)(&pwr_module))) {
++        pwr_module->init(pwr_module);
++    } else {
++        fprintf(stderr, "Failed to initialize PowerHAL, Ambient mode may not work\n");
++    }
+ 
+     // Open hardware composer
+     HWC_PLUGIN_ASSERT_ZERO(hw_get_module(HWC_HARDWARE_MODULE_ID, (const hw_module_t **)(&hwc_module)));
+diff --git a/hwcomposer/hwcomposer_backend_v11.cpp b/hwcomposer/hwcomposer_backend_v11.cpp
+index fad8e62..1db55ff 100644
+--- a/hwcomposer/hwcomposer_backend_v11.cpp
++++ b/hwcomposer/hwcomposer_backend_v11.cpp
+@@ -374,10 +374,14 @@ HwComposerBackend_v11::sleepDisplay(bool sleep)
+             HWC_PLUGIN_EXPECT_ZERO(hwc_device->blank(hwc_device, 0, 1));
+ 
+         // Enter non-interactive state after turning off the screen.
+-        pwr_device->setInteractive(pwr_device, false);
++        if (pwr_device) {
++            pwr_device->setInteractive(pwr_device, false);
++        }
+     } else {
+         // Enter interactive state prior to turning on the screen.
+-        pwr_device->setInteractive(pwr_device, true);
++        if (pwr_device) {
++            pwr_device->setInteractive(pwr_device, true);
++        }
+ 
+ #ifdef HWC_DEVICE_API_VERSION_1_4
+         if (hwc_version == HWC_DEVICE_API_VERSION_1_4) {
+-- 
+2.29.0
+

--- a/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
+++ b/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
@@ -18,6 +18,7 @@ SRC_URI = "git://github.com/mer-hybris/qt5-qpa-hwcomposer-plugin;protocol=https 
            file://0005-hwcomposer_backend_v11-fix-compatibility-with-qtbase.patch;striplevel=2 \
            file://0006-Add-ambient-mode-display-support.patch;striplevel=2 \
            file://0007-backend-setInteractive-based-on-display-state.patch;striplevel=2 \
+           file://0008-backend-Don-t-crash-when-power-HAL-doesn-t-exist.patch;striplevel=2 \
 "
 S = "${WORKDIR}/git/hwcomposer"
 SRCREV = "bb95d09b893761c25409363e15f7048739c436ba"


### PR DESCRIPTION
Some platforms (tetra) don't have a working PowerHAL, Always-on-Display might not work, but this is not a fatal error.