### PR TITLE
qtlocation: Remove GeoClue2 plugin.

### DIFF
--- a/recipes-qt/qt5/qtlocation_git.bbappend
+++ b/recipes-qt/qt5/qtlocation_git.bbappend
@@ -1,2 +1,6 @@
 PACKAGECONFIG = "geoclue"
 RDEPENDS_${PN} += "geoclue"
+
+do_install_append() {
+    rm ${D}/usr/lib/plugins/position/libqtposition_geoclue2.so
+}


### PR DESCRIPTION
We only have GeoClue 0.12.99 installed. For some reason Qt still decides that it should use the GeoClue2 plugin.
Removing the plugin fixes this issue.