### PR TITLE
Add and enable Color Emoji.

### DIFF
--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bb
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bb
@@ -14,7 +14,7 @@ S = "${WORKDIR}/git"
 inherit qmake5
 
 DEPENDS += "lipstick qttools-native timed"
-RDEPENDS_${PN} += "qtdeclarative-qmlplugins qml-asteroid qtwayland-plugins nemo-qml-plugin-time nemo-qml-plugin-contextkit nemo-qml-plugin-configuration asteroid-wallpapers ttf-asteroid-fonts"
+RDEPENDS_${PN} += "qtdeclarative-qmlplugins qml-asteroid qtwayland-plugins nemo-qml-plugin-time nemo-qml-plugin-contextkit nemo-qml-plugin-configuration asteroid-wallpapers ttf-asteroid-fonts ttf-noto-emoji-color"
 FILES_${PN} += "/usr/share/asteroid-launcher/ /usr/lib/systemd/user/ /usr/share/translations/ /usr/lib/systemd/user/default.target.wants/"
 
 do_install_append() {

--- a/recipes-graphics/freetype/freetype_%.bbappend
+++ b/recipes-graphics/freetype/freetype_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG_append = " pixmap"

--- a/recipes-graphics/ttf-fonts/ttf-noto-emoji/69-emoji.conf
+++ b/recipes-graphics/ttf-fonts/ttf-noto-emoji/69-emoji.conf
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+
+<!-- Priority:
+ ! 1. The generic family OR specific family
+ ! 2. The emoji font family (defined in 60-generic.conf)
+ ! 3. All the rest
+ !-->
+
+    <alias binding="weak">
+        <family>sans-serif</family>
+        <prefer>
+            <family>emoji</family>
+        </prefer>
+    </alias>
+
+    <alias binding="weak">
+        <family>serif</family>
+        <prefer>
+            <family>emoji</family>
+        </prefer>
+    </alias>
+
+    <alias binding="weak">
+        <family>monospace</family>
+        <prefer>
+            <family>emoji</family>
+        </prefer>
+    </alias>
+</fontconfig>

--- a/recipes-graphics/ttf-fonts/ttf-noto-emoji_20190815.bb
+++ b/recipes-graphics/ttf-fonts/ttf-noto-emoji_20190815.bb
@@ -7,7 +7,8 @@ INHIBIT_DEFAULT_DEPS = "1"
 
 inherit allarch fontcache
 
-SRC_URI = "git://github.com/googlefonts/noto-emoji;protocol=https"
+SRC_URI = "git://github.com/googlefonts/noto-emoji;protocol=https \
+    file://69-emoji.conf"
 SRCREV = "833a43d03246a9325e748a2d783006454d76ff66"
 
 PACKAGES = "${PN}-color ${PN}-regular"
@@ -15,13 +16,20 @@ FONT_PACKAGES = "${PN}-color ${PN}-regular"
 
 S = "${WORKDIR}/git"
 
-FILES_${PN} += "/home/ceres/.config/fontconfig/conf.d"
+FILES_${PN}-color += "/home/ceres/.config/fontconfig/conf.d"
+FILES_${PN}-regular += "/home/ceres/.config/fontconfig/conf.d"
 FILES_${PN}-color += "/usr/share/fonts/NotoColorEmoji.ttf"
 FILES_${PN}-regular += "/usr/share/fonts/NotoEmoji-Regular.ttf"
 
 do_install() {
     install -d ${D}/usr/share/fonts/
     find ./ -name '*.[to]tf' -exec install -m 0644 {} ${D}/usr/share/fonts \;
+
+    install -d ${D}/home/ceres/.config/fontconfig/conf.d/
+    install -m 644 ../69-emoji.conf ${D}/home/ceres/.config/fontconfig/conf.d/
 }
 
 do_compile[noexec] = "1"
+
+INSANE_SKIP_${PN}-color += "host-user-contaminated"
+INSANE_SKIP_${PN}-regular += "host-user-contaminated"

--- a/recipes-graphics/ttf-fonts/ttf-noto-emoji_20190815.bb
+++ b/recipes-graphics/ttf-fonts/ttf-noto-emoji_20190815.bb
@@ -1,0 +1,27 @@
+SUMMARY = "Google noto emoji font pack"
+SECTION = "fonts"
+HOMEPAGE = "https://github.com/googlefonts/noto-emoji"
+LICENSE = "OFL-1.1"
+LIC_FILES_CHKSUM = "file://fonts/LICENSE;md5=55719faa0112708e946b820b24b14097"
+INHIBIT_DEFAULT_DEPS = "1"
+
+inherit allarch fontcache
+
+SRC_URI = "git://github.com/googlefonts/noto-emoji;protocol=https"
+SRCREV = "833a43d03246a9325e748a2d783006454d76ff66"
+
+PACKAGES = "${PN}-color ${PN}-regular"
+FONT_PACKAGES = "${PN}-color ${PN}-regular"
+
+S = "${WORKDIR}/git"
+
+FILES_${PN} += "/home/ceres/.config/fontconfig/conf.d"
+FILES_${PN}-color += "/usr/share/fonts/NotoColorEmoji.ttf"
+FILES_${PN}-regular += "/usr/share/fonts/NotoEmoji-Regular.ttf"
+
+do_install() {
+    install -d ${D}/usr/share/fonts/
+    find ./ -name '*.[to]tf' -exec install -m 0644 {} ${D}/usr/share/fonts \;
+}
+
+do_compile[noexec] = "1"


### PR DESCRIPTION
This PR adds the necessary stuff to make color emoji work.
Some of these commits can be adjusted/removed when we eventually upgrade to something more recent than `warrior`:
`freetype: Enable pixmap`: Is enabled here https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/recipes-graphics/freetype?id=2673d8005c1c6ed27a8a7e3903b904e0c0711320
`ttf-noto-emoji: Add Google Noto Emoji`: Added here: https://github.com/openembedded/meta-openembedded/commit/08a97cb0e03b7b14bf4ef2632f2db24a86ccae8b

I tried to make the `69-emoji.conf` work system wide, but could not get it to work for some reason, what I tried:
- Copy `69-emoji.conf` to /usr/share/fontconfig/conf.avail/
- Copy `69-emoji.conf` to /etc/fonts/conf.d/
- Change the binding from `weak` to `strong`
- Rename `69-emoji.conf` to `00-emoji.conf` and `99-emoji.conf`
- Run `fc-cache -f -v` on every change to refresh the font cache (run for both root and ceres).

Depending on what you prefer, we could also merge this PR into https://github.com/AsteroidOS/asteroid-fonts.

Preview:
![Screenshot_20201216_145722](https://user-images.githubusercontent.com/7857908/102621869-829d6e80-4140-11eb-9759-c1aa6b4c1e86.jpg)

![Screenshot_20201216_145733](https://user-images.githubusercontent.com/7857908/102621856-7fa27e00-4140-11eb-92ae-b75002a8f19b.jpg)
