### PR TITLE
Add support for community repositories

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -17,13 +17,3 @@ EXTRA_USERS_PARAMS = "groupadd system; \
 
 IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_ROOTFS_EXTRA_SPACE = "131072"
-
-python do_package_index () {
-    from oe.rootfs import generate_index_files
-    generate_index_files(d)
-}
-do_package_index[depends] += "${PACKAGEINDEXDEPS}"
-do_package_index[dirs] = "${TOPDIR}"
-do_package_index[umask] = "022"
-do_package_index[file-checksums] += "${POSTINST_INTERCEPT_CHECKSUMS}"
-addtask do_package_index after do_rootfs before do_image

--- a/recipes-asteroid/asteroid-package-feed/asteroid-package-feed.bb
+++ b/recipes-asteroid/asteroid-package-feed/asteroid-package-feed.bb
@@ -1,0 +1,30 @@
+SUMMARY = "Create a package index from the packages included in rootfs and community packages."
+LICENSE = "MIT"
+
+INHIBIT_DEFAULT_DEPS = "1"
+PACKAGES = ""
+
+# A set of packages to build for the package feed but that are not included in rootfs.
+PACKAGE_FEED ?= ""
+
+inherit nopackages
+
+deltask do_fetch
+deltask do_unpack
+deltask do_patch
+deltask do_configure
+deltask do_compile
+deltask do_install
+deltask do_populate_lic
+deltask do_populate_sysroot
+
+do_package_index[nostamp] = "1"
+do_package_index[depends] += "${PACKAGEINDEXDEPS}"
+do_package_index[depends] += "${@oe.utils.build_depends_string(d.getVar('PACKAGE_FEED'), 'do_package_write_ipk')}"
+
+python do_package_index() {
+    from oe.rootfs import generate_index_files
+    generate_index_files(d)
+}
+addtask do_package_index before do_build
+EXCLUDE_FROM_WORLD = "1"


### PR DESCRIPTION
This PR adds the ability for other layers to define a set of packages to install in the package feed for use with `opkg`. An example use is like what I've done in the `meta-games` repo: https://github.com/MagneFire/meta-games/blob/community_repo/conf/layer.conf#L13.

A nice thing is that packages won't be build in the package feed when a layer doesn't exist. So it decouples the community packages from the main repos.

Also, because of this added functionality I have removed the creation of the package feed from the `bitbake asteroid-image` command.
So users building AsteroidOS don't actually build the package feed. This however does mean that an adjustment has to be made on the build server such that after a asteroid-image build the `bitbake asteroid-package-feed` command is used to update the package feed and with it the community packages.