### PR TITLE
libhybris: Provide patch to force GLESv2.

### DIFF
--- a/recipes-core/libhybris/libhybris/0004-Report-support-for-only-2.0-instead-of-3.0.patch
+++ b/recipes-core/libhybris/libhybris/0004-Report-support-for-only-2.0-instead-of-3.0.patch
@@ -1,0 +1,38 @@
+From 8b8d271db718866a777ab9d5876a9c42455856cb Mon Sep 17 00:00:00 2001
+From: MagneFire <IDaNLContact@gmail.com>
+Date: Sat, 1 May 2021 15:08:17 +0200
+Subject: [PATCH] Report support for only 2.0 instead of 3.0. It looks like we
+ experience glitches when supporting 3.0.
+
+---
+ hybris/glesv2/glesv2.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/hybris/glesv2/glesv2.c b/hybris/glesv2/glesv2.c
+index 716bbde..ed7f366 100644
+--- a/hybris/glesv2/glesv2.c
++++ b/hybris/glesv2/glesv2.c
+@@ -105,7 +105,19 @@ HYBRIS_IMPLEMENT_VOID_FUNCTION3(glesv2, glGetShaderiv, GLuint, GLenum, GLint *);
+ HYBRIS_IMPLEMENT_VOID_FUNCTION4(glesv2, glGetShaderInfoLog, GLuint, GLsizei, GLsizei *, GLchar *);
+ HYBRIS_IMPLEMENT_VOID_FUNCTION4(glesv2, glGetShaderPrecisionFormat, GLenum, GLenum, GLint *, GLint *);
+ HYBRIS_IMPLEMENT_VOID_FUNCTION4(glesv2, glGetShaderSource, GLuint, GLsizei, GLsizei *, GLchar *);
+-HYBRIS_IMPLEMENT_FUNCTION1(glesv2, const GLubyte *, glGetString, GLenum);
++const GLubyte* glGetString (GLenum n1)
++{
++        static const GLubyte * (*f)(GLenum) FP_ATTRIB = NULL;
++        HYBRIS_DLSYSM(glesv2, &f, "glGetString");
++       // Some platforms have glitchy 3.0 driver. Report only 2.0 support.
++	if (n1 == GL_VERSION) {
++		static GLubyte glGetString_versionString[64];
++		snprintf((char *)glGetString_versionString, sizeof(glGetString_versionString), "OpenGL ES 2.0 (%s)", f(n1));
++		return glGetString_versionString;
++	}
++
++       return f(n1);
++}
+ HYBRIS_IMPLEMENT_VOID_FUNCTION3(glesv2, glGetTexParameterfv, GLenum, GLenum, GLfloat *);
+ HYBRIS_IMPLEMENT_VOID_FUNCTION3(glesv2, glGetTexParameteriv, GLenum, GLenum, GLint *);
+ HYBRIS_IMPLEMENT_VOID_FUNCTION3(glesv2, glGetUniformfv, GLuint, GLint, GLfloat *);
+-- 
+2.31.1
+

--- a/recipes-qt/qt5/qtwayland/0001-Forces-GLES2-the-dirty-way.patch
+++ b/recipes-qt/qt5/qtwayland/0001-Forces-GLES2-the-dirty-way.patch
@@ -1,4 +1,4 @@
-From ff4173faa89371f07c7e6780605806abf4b00945 Mon Sep 17 00:00:00 2001
+From 8511be9f9fc6be8aeddceeeb39836c2794ba2b44 Mon Sep 17 00:00:00 2001
 From: Florent Revest <revestflo@gmail.com>
 Date: Thu, 17 Sep 2015 13:32:00 +0200
 Subject: [PATCH] Forces GLES2 the dirty way
@@ -8,10 +8,10 @@ Subject: [PATCH] Forces GLES2 the dirty way
  1 file changed, 3 insertions(+), 6 deletions(-)
 
 diff --git a/src/hardwareintegration/client/wayland-egl/qwaylandglcontext.cpp b/src/hardwareintegration/client/wayland-egl/qwaylandglcontext.cpp
-index 02affe31..7560cee7 100644
+index ccebf43d..cface69a 100644
 --- a/src/hardwareintegration/client/wayland-egl/qwaylandglcontext.cpp
 +++ b/src/hardwareintegration/client/wayland-egl/qwaylandglcontext.cpp
-@@ -357,12 +357,9 @@ void QWaylandGLContext::updateGLFormat()
+@@ -363,12 +363,9 @@ void QWaylandGLContext::updateGLFormat()
              || m_format.renderableType() == QSurfaceFormat::OpenGLES) {
              const GLubyte *s = glGetString(GL_VERSION);
              if (s) {

--- a/recipes-qt/qt5/qtwayland/0002-Revert-most-of-Remove-QWaylandExtendedSurface-from-t.patch
+++ b/recipes-qt/qt5/qtwayland/0002-Revert-most-of-Remove-QWaylandExtendedSurface-from-t.patch
@@ -1,4 +1,4 @@
-From 4915791a5581196ec5f29b6e5a1a82e195482cf8 Mon Sep 17 00:00:00 2001
+From c79cc3285f49494054cd923f8558b14905f5218c Mon Sep 17 00:00:00 2001
 From: Florent Revest <revestflo@gmail.com>
 Date: Mon, 1 Oct 2018 23:18:42 +0200
 Subject: [PATCH] Revert most of "Remove QWaylandExtendedSurface* from the
@@ -14,7 +14,7 @@ Subject: [PATCH] Revert most of "Remove QWaylandExtendedSurface* from the
  create mode 100644 src/compositor/extensions/qwlextendedsurface_p.h
 
 diff --git a/src/compositor/extensions/extensions.pri b/src/compositor/extensions/extensions.pri
-index 64b1439b..8b6ca62a 100644
+index e52bbfd6..ef1b552d 100644
 --- a/src/compositor/extensions/extensions.pri
 +++ b/src/compositor/extensions/extensions.pri
 @@ -5,6 +5,7 @@ CONFIG += generated_privates
@@ -25,15 +25,15 @@ index 64b1439b..8b6ca62a 100644
      ../extensions/touch-extension.xml \
      ../extensions/qt-key-unstable-v1.xml \
      ../extensions/qt-windowmanager.xml \
-@@ -19,6 +20,7 @@ WAYLANDSERVERSOURCES += \
-     ../3rdparty/protocol/idle-inhibit-unstable-v1.xml \
+@@ -20,6 +21,7 @@ WAYLANDSERVERSOURCES += \
+     ../extensions/qt-texture-sharing-unstable-v1.xml \
  
  HEADERS += \
 +    extensions/qwlextendedsurface_p.h \
      extensions/qwlqttouch_p.h \
      extensions/qwlqtkey_p.h \
      extensions/qwaylandshell.h \
-@@ -54,6 +56,7 @@ HEADERS += \
+@@ -55,6 +57,7 @@ HEADERS += \
      extensions/qwaylandivisurface_p.h \
  
  SOURCES += \

--- a/recipes-qt/qt5/qtwayland/0003-xdg-shell-Add-support-for-extended-surfaces.patch
+++ b/recipes-qt/qt5/qtwayland/0003-xdg-shell-Add-support-for-extended-surfaces.patch
@@ -1,4 +1,4 @@
-From b1332a0a8abfba31479f9b892027f75947fb2fae Mon Sep 17 00:00:00 2001
+From 0b1b556eb06cd5e5c249310f0eb39382f57aef14 Mon Sep 17 00:00:00 2001
 From: MagneFire <IDaNLContact@gmail.com>
 Date: Sat, 3 Oct 2020 22:19:18 +0200
 Subject: [PATCH] xdg-shell: Add support for extended surfaces.


### PR DESCRIPTION
See main PR: https://github.com/AsteroidOS/meta-sturgeon-hybris/pull/16

Additionally, I noticed some warnings with `qtwayland`, refreshing the patches fixes this too.