### PR TITLE
Port to CMake

### DIFF
--- a/recipes-asteroid/asteroid-alarmclock/asteroid-alarmclock_git.bb
+++ b/recipes-asteroid/asteroid-alarmclock/asteroid-alarmclock_git.bb
@@ -8,14 +8,8 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit cmake_qt5
 
-DEPENDS += "qml-asteroid nemo-qml-plugin-alarms qttools-native qtdeclarative-native"
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native nemo-qml-plugin-alarms qttools-native qtdeclarative-native"
 RDEPENDS_${PN} += "nemo-qml-plugin-alarms"
 FILES_${PN} += "/usr/share/translations/ /usr/lib/systemd/user/alarmpresenter.service /usr/share/dbus-1/services/com.nokia.voland.service"
-
-do_install_append() {
-    lrelease -idbased ${S}/alarmclock/i18n/asteroid-alarmclock.*.ts
-    install -d ${D}/usr/share/translations/
-    cp ${S}/alarmclock/i18n/asteroid-alarmclock.*.qm ${D}/usr/share/translations/
-}

--- a/recipes-asteroid/asteroid-calculator/asteroid-calculator_git.bb
+++ b/recipes-asteroid/asteroid-calculator/asteroid-calculator_git.bb
@@ -8,6 +8,11 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit cmake_qt5
 
-DEPENDS += "qml-asteroid qtdeclarative-native"
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native qtdeclarative-native qttools-native"
+
+do_install_append() {
+    # This app only uses translations for the desktop shortcut.
+    rm -rvf ${D}/usr/share/translations/
+}

--- a/recipes-asteroid/asteroid-calendar/asteroid-calendar_git.bb
+++ b/recipes-asteroid/asteroid-calendar/asteroid-calendar_git.bb
@@ -8,14 +8,8 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit cmake_qt5
 
-DEPENDS += "qml-asteroid nemo-qml-plugin-calendar qttools-native qtdeclarative-native"
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native nemo-qml-plugin-calendar qttools-native qtdeclarative-native"
 RDEPENDS_${PN} += "nemo-qml-plugin-calendar"
 FILES_${PN} += "/usr/share/translations/"
-
-do_install_append() {
-    lrelease -idbased ${S}/i18n/asteroid-calendar.*.ts
-    install -d ${D}/usr/share/translations/
-    cp ${S}/i18n/asteroid-calendar.*.qm ${D}/usr/share/translations/
-}

--- a/recipes-asteroid/asteroid-camera/asteroid-camera_git.bb
+++ b/recipes-asteroid/asteroid-camera/asteroid-camera_git.bb
@@ -8,8 +8,12 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit cmake_qt5
 
-DEPENDS += "qml-asteroid qttools-native qtdeclarative-native qtmultimedia"
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native qtmultimedia"
 RDEPENDS_${PN} += "qtmultimedia"
-FILES_${PN} += "/usr/share/translations/"
+
+do_install_append() {
+    # This app only uses translations for the desktop shortcut.
+    rm -rvf ${D}/usr/share/translations/
+}

--- a/recipes-asteroid/asteroid-compass/asteroid-compass_git.bb
+++ b/recipes-asteroid/asteroid-compass/asteroid-compass_git.bb
@@ -8,7 +8,12 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit cmake_qt5
 
-DEPENDS += "qml-asteroid qtdeclarative-native"
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"
 RDEPENDS_${PN} += "qtsensors qtsensors-qmlplugins qtsensors-plugins"
+
+do_install_append() {
+    # This app only uses translations for the desktop shortcut.
+    rm -rvf ${D}/usr/share/translations/
+}

--- a/recipes-asteroid/asteroid-flashlight/asteroid-flashlight_git.bb
+++ b/recipes-asteroid/asteroid-flashlight/asteroid-flashlight_git.bb
@@ -8,7 +8,11 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit cmake_qt5
 
-DEPENDS += "qml-asteroid qttools-native qtdeclarative-native"
-FILES_${PN} += "/usr/share/translations/"
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"
+
+do_install_append() {
+    # This app only uses translations for the desktop shortcut.
+    rm -rvf ${D}/usr/share/translations/
+}

--- a/recipes-asteroid/asteroid-hrm/asteroid-hrm_git.bb
+++ b/recipes-asteroid/asteroid-hrm/asteroid-hrm_git.bb
@@ -8,7 +8,11 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit cmake_qt5
 
-DEPENDS += "qml-asteroid qtsensors qttools-native qtdeclarative-native"
-FILES_${PN} += "/usr/share/translations/"
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native qtsensors qttools-native qtdeclarative-native"
+
+do_install_append() {
+    # This app only uses translations for the desktop shortcut.
+    rm -rvf ${D}/usr/share/translations/
+}

--- a/recipes-asteroid/asteroid-music/asteroid-music_git.bb
+++ b/recipes-asteroid/asteroid-music/asteroid-music_git.bb
@@ -8,14 +8,8 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit cmake_qt5
 
-DEPENDS += "qml-asteroid qtmpris qttools-native qtdeclarative-native"
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native qtmpris qttools-native qtdeclarative-native"
 RDEPENDS_${PN} += "qtmpris"
 FILES_${PN} += "/usr/share/translations/"
-
-do_install_append() {
-    lrelease -idbased ${S}/i18n/asteroid-music.*.ts
-    install -d ${D}/usr/share/translations/
-    cp ${S}/i18n/asteroid-music.*.qm ${D}/usr/share/translations/
-}

--- a/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
+++ b/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
@@ -8,14 +8,8 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit cmake_qt5
 
-DEPENDS += "qml-asteroid nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus qttools-native qtdeclarative-native"
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus qttools-native qtdeclarative-native"
 RDEPENDS_${PN} += "nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus qtmultimedia-qmlplugins libconnman-qt5-qmlplugins"
 FILES_${PN} += "/usr/share/translations/"
-
-do_install_append() {
-    lrelease -idbased ${S}/i18n/asteroid-settings.*.ts
-    install -d ${D}/usr/share/translations/
-    cp ${S}/i18n/asteroid-settings.*.qm ${D}/usr/share/translations/
-}

--- a/recipes-asteroid/asteroid-stopwatch/asteroid-stopwatch_git.bb
+++ b/recipes-asteroid/asteroid-stopwatch/asteroid-stopwatch_git.bb
@@ -8,6 +8,11 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit cmake_qt5
 
-DEPENDS += "qml-asteroid qtdeclarative-native"
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"
+
+do_install_append() {
+    # This app only uses translations for the desktop shortcut.
+    rm -rvf ${D}/usr/share/translations/
+}

--- a/recipes-asteroid/asteroid-timer/asteroid-timer_git.bb
+++ b/recipes-asteroid/asteroid-timer/asteroid-timer_git.bb
@@ -8,7 +8,12 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit cmake_qt5
 
-DEPENDS += "qml-asteroid nemo-qml-plugin-dbus nemo-keepalive qtdeclarative-native"
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native nemo-qml-plugin-dbus nemo-keepalive qttools-native qtdeclarative-native"
 RDEPENDS_${PN} += "nemo-keepalive"
+
+do_install_append() {
+    # This app only uses translations for the desktop shortcut.
+    rm -rvf ${D}/usr/share/translations/
+}

--- a/recipes-asteroid/asteroid-weather/asteroid-weather_git.bb
+++ b/recipes-asteroid/asteroid-weather/asteroid-weather_git.bb
@@ -8,14 +8,8 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit cmake_qt5
 
-DEPENDS += "qml-asteroid nemo-qml-plugin-configuration qttools-native qtdeclarative-native"
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native nemo-qml-plugin-configuration qttools-native qtdeclarative-native"
 RDEPENDS_${PN} += "nemo-qml-plugin-configuration"
 FILES_${PN} += "/usr/share/translations/"
-
-do_install_append() {
-    lrelease -idbased ${S}/i18n/asteroid-weather.*.ts
-    install -d ${D}/usr/share/translations/
-    cp ${S}/i18n/asteroid-weather.*.qm ${D}/usr/share/translations/
-}

--- a/recipes-asteroid/qml-asteroid/asteroid-generate-desktop-native_git.bb
+++ b/recipes-asteroid/qml-asteroid/asteroid-generate-desktop-native_git.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Desktop file generation for AsteroidOS apps"
+HOMEPAGE = "https://github.com/AsteroidOS/qml-asteroid.git"
+LICENSE = "LGPL-2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=1702a92c723f09e3fab3583b165a8d90"
+
+SRC_URI = "git://github.com/AsteroidOS/qml-asteroid.git;protocol=https"
+SRCREV = "${AUTOREV}"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+inherit native
+
+do_install() {
+    install -d ${D}/${bindir}
+    install -m 755 ${S}/generate-desktop.sh ${D}/${bindir}/asteroid-generate-desktop
+}

--- a/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
+++ b/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
@@ -9,11 +9,11 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit cmake_qt5
 
-DEPENDS += "asteroid-machine-config qtdeclarative qtsvg qtvirtualkeyboard mlite mapplauncherd-booster-qtcomponents qtdeclarative-native"
+DEPENDS += "extra-cmake-modules asteroid-machine-config qtdeclarative qtsvg qtvirtualkeyboard mlite mapplauncherd-booster-qtcomponents qtdeclarative-native"
 RDEPENDS_${PN} += "asteroid-machine-config qtsvg-plugins qtvirtualkeyboard asteroid-icons-ion"
 
 FILES_${PN} += "/usr/lib /usr/share/icons/asteroid/"
 FILES_${PN}-dbg += "/usr/lib/qml/org/asteroid/controls/.debug/ /usr/lib/qml/QtQuick/Controls/Styles/Asteroid/.debug/"
-FILES_${PN}-dev += "/usr/lib/mkspecs/"
+FILES_${PN}-dev += "/usr/lib/mkspecs/ /usr/share/asteroidapp/cmake/ /usr/bin/asteroid-generate-desktop"

--- a/recipes-devtools/cmake/extra-cmake-modules_git.bb
+++ b/recipes-devtools/cmake/extra-cmake-modules_git.bb
@@ -1,0 +1,15 @@
+SUMMARY = "Extra modules and scripts for CMake"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://COPYING-CMAKE-SCRIPTS;md5=54c7042be62e169199200bc6477f04d1"
+
+SRC_URI = "git://invent.kde.org/frameworks/extra-cmake-modules.git;protocol=https;branch=master"
+SRCREV = "d88db6a1469bdcb48e64f265d35a6f7867767b54"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+EXTRA_OECMAKE += "-DBUILD_TESTING=off -DBUILD_HTML_DOCS=OFF -DBUILD_QTHELP_DOCS=ON"
+
+inherit cmake
+
+FILES_${PN}-dev += "${datadir}/ECM"

--- a/recipes-qt/qt5/qtbase-native_git.bbappend
+++ b/recipes-qt/qt5/qtbase-native_git.bbappend
@@ -1,0 +1,2 @@
+PACKAGECONFIG_append = " gui "
+PACKAGECONFIG_CONFARGS_append = " -make tools "


### PR DESCRIPTION
This is part of the excellent work by @PureTryOut https://github.com/AsteroidOS/qml-asteroid/pull/14!

In order to reduce image space used, the built translation files are removed when they were only used for the .desktop file generation.

This PR does not include the needed changes for asteroid-launcher as the relevant PR (https://github.com/AsteroidOS/asteroid-launcher/pull/49) for that one depends on the removal of statefs: https://github.com/AsteroidOS/meta-asteroid/pull/61

I should mention that even though this work now also checks for runtime QML modules. It fails to find all of them. This currently results into a compile time warning, that is only visible when looking at the configure logs.