### PR TITLE
Resolve library conflict between libhybris and wayland

### DIFF
--- a/recipes-core/libhybris/libhybris_git.bbappend
+++ b/recipes-core/libhybris/libhybris_git.bbappend
@@ -5,3 +5,9 @@ DEPENDS:append = " wayland "
 EXTRA_OECONF:append = " --enable-wayland --with-default-egl-platform=wayland --with-default-hybris-ld-library-path=/usr/libexec/hal-droid/system/lib:/vendor/lib:/system/lib"
 
 COMPATIBLE_MACHINE=""
+
+do_install:append () {
+# libwayland-egl has been moved to wayland 1.15+
+  rm -f ${D}${libdir}/libwayland-egl*
+  rm -f ${D}${libdir}/pkgconfig/wayland-egl.pc
+}


### PR DESCRIPTION
According to https://github.com/agherzan/meta-raspberrypi/issues/243#issuecomment-388374552 in Wayland 1.15+ certain libraries that were provided by just libhybris previously are now also provided by Wayland, this causes issues during packaging (Specifically with gstreamer1.0-plugins-base-1.18.5-r0), the above fixes it and allows it to package by only packing the libs from one source.