### PR TITLE
Add support for Bluetooth via Bluebinder.

### DIFF
--- a/recipes-core/bluebinder/bluebinder.bb
+++ b/recipes-core/bluebinder/bluebinder.bb
@@ -1,0 +1,38 @@
+# Copyright (c) 2019 Christophe Chapuis <chris.chapuis@gmail.com>
+
+DESCRIPTION = "Simple proxy for using Android binder based bluetooth through vhci."
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://bluebinder.c;beginline=1;endline=27;md5=430727b8efeca344ab89eeb635b4fa79"
+
+SRC_URI = "git://github.com/mer-hybris/bluebinder.git \
+           file://0001-Use-CC-as-compiler.patch \
+"
+SRCREV = "419ab4a36fd61f841e7b1070b92b5e23ea813b63"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+DEPENDS = "libgbinder glib-2.0 libglibutil bluez5 systemd"
+
+inherit pkgconfig
+inherit systemd
+
+CFLAGS += "--sysroot=${RECIPE_SYSROOT} ${LDFLAGS}"
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "bluebinder.service"
+
+do_install() {
+    make install DESTDIR=${D}
+
+    install -d ${D}${sbindir}
+    install -m 0755 ${S}/bluebinder_post.sh ${D}${sbindir}/bluebinder_post.sh
+    install -m 0755 ${S}/bluebinder_wait.sh ${D}${sbindir}/bluebinder_wait.sh
+
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${S}/bluebinder.service ${D}${systemd_unitdir}/system/
+}
+
+FILES:${PN} += "${sbindir}/bluebinder_post.sh ${sbindir}/bluebinder_wait.sh"

--- a/recipes-core/bluebinder/bluebinder/0001-Use-CC-as-compiler.patch
+++ b/recipes-core/bluebinder/bluebinder/0001-Use-CC-as-compiler.patch
@@ -1,0 +1,53 @@
+diff --git a/Makefile b/Makefile
+index 2cafc51..a9e4fce 100644
+--- a/Makefile
++++ b/Makefile
+@@ -10,12 +10,12 @@ endif
+ build: bluebinder
+ 
+ bluebinder: bluebinder.c
+-	gcc $(CFLAGS) -Wall -flto $^ `pkg-config --cflags --libs $(DEPEND_LIBS)` -DUSE_SYSTEMD=$(USE_SYSTEMD) -o $@
++	${CC} $(CFLAGS) -Wall -flto $^ `pkg-config --cflags --libs $(DEPEND_LIBS)` -DUSE_SYSTEMD=$(USE_SYSTEMD) -o $@
+ 
+ install:
+ 	mkdir -p $(DESTDIR)/usr/sbin
+ 	cp bluebinder $(DESTDIR)/usr/sbin
+ 
+ clean:
+-	rm bluebinder
++	rm -f bluebinder
+ 
+diff --git a/bluebinder.service b/bluebinder.service
+index a9f6c56..52eae10 100644
+--- a/bluebinder.service
++++ b/bluebinder.service
+@@ -1,26 +1,15 @@
+ [Unit]
+ Description=Simple proxy for using android binder based bluetooth through vhci.
+-After=droid-hal-init.service
++After=android-system.service
+ Before=bluetooth.service
+ 
+ [Service]
+ Type=notify
+-ExecStartPre=/usr/bin/droid/bluebinder_wait.sh
++ExecStartPre=/usr/sbin/bluebinder_wait.sh
+ ExecStart=/usr/sbin/bluebinder
+-ExecStartPost=/usr/bin/droid/bluebinder_post.sh
+ Restart=always
+ TimeoutStartSec=60
+-# Sandboxing
+-CapabilityBoundingSet=CAP_DAC_READ_SEARCH
+-DeviceAllow=/dev/hwbinder rw
+-DeviceAllow=/dev/vhci rw
+-DevicePolicy=strict
+-NoNewPrivileges=yes
+-PrivateNetwork=true
+-PrivateTmp=yes
+-ProtectHome=yes
+-ProtectSystem=full
+ 
+ [Install]
+-WantedBy=graphical.target
++WantedBy=multi-user.target
+ 

--- a/recipes-core/libgbinder/libgbinder.bb
+++ b/recipes-core/libgbinder/libgbinder.bb
@@ -1,0 +1,31 @@
+# Copyright (c) 2019 Christophe Chapuis <chris.chapuis@gmail.com>
+
+DESCRIPTION = "Library used to interact with Android's binder module."
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=24f23d12bbc59c7e5ab483c52a172555"
+
+SRC_URI = "git://github.com/mer-hybris/libgbinder.git \
+           file://gbinder.conf \
+"
+SRCREV = "88df2edb9533fc4680fe59f3113f839d0cf9c77a"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+DEPENDS = "glib-2.0 libglibutil"
+
+inherit pkgconfig
+
+EXTRA_OEMAKE = "KEEP_SYMBOLS=1"
+PARALLEL_MAKE = ""
+
+do_install() {
+    make install DESTDIR=${D}
+    make install-dev DESTDIR=${D}
+    
+    # Install libgbinder's config for Halium 9.0
+    install -d ${D}${sysconfdir}
+    install -m 0644 ${WORKDIR}/gbinder.conf ${D}${sysconfdir}/gbinder.conf
+}
+
+FILES:${PN} += " ${sysconfdir}"

--- a/recipes-core/libgbinder/libgbinder/gbinder.conf
+++ b/recipes-core/libgbinder/libgbinder/gbinder.conf
@@ -1,0 +1,2 @@
+[General]
+ApiLevel = 28

--- a/recipes-core/libglibutil/libglibutil.bb
+++ b/recipes-core/libglibutil/libglibutil.bb
@@ -1,0 +1,24 @@
+# Copyright (c) 2019 Christophe Chapuis <chris.chapuis@gmail.com>
+
+DESCRIPTION = "Library of glib utilities."
+LICENSE = "BSD-3-Clause"
+SECTION = "webos/support"
+LIC_FILES_CHKSUM = "file://src/gutil_log.c;beginline=1;endline=31;md5=c476c5938ec00208b29c1c1743b4a006"
+
+SRC_URI = "git://github.com/sailfishos/libglibutil.git;protocol=https"
+SRCREV = "dfcf23805b49307e63d1090aec69255de4a167ea"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+DEPENDS = "glib-2.0"
+
+inherit pkgconfig
+
+EXTRA_OEMAKE = "KEEP_SYMBOLS=1"
+PARALLEL_MAKE = ""
+
+do_install() {
+    make install DESTDIR=${D}
+    make install-dev DESTDIR=${D}
+}

--- a/recipes-core/libglibutil/libglibutil/0001-Makefile-use-CC-from-bitbake.patch
+++ b/recipes-core/libglibutil/libglibutil/0001-Makefile-use-CC-from-bitbake.patch
@@ -1,0 +1,26 @@
+From da3e6d2bdb00624f843adcd3ae4f8a1a1e3609e2 Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Sat, 13 Jul 2019 12:38:38 +0000
+Subject: [PATCH] Makefile: use CC from bitbake
+
+---
+ Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index c4e2600..702556a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -65,7 +65,9 @@ endif
+ # Tools and flags
+ #
+ 
++ifndef CC
+ CC = $(CROSS_COMPILE)gcc
++endif
+ LD = $(CC)
+ WARNINGS = -Wall
+ INCLUDES = -I$(INCLUDE_DIR)
+-- 
+2.17.0
+


### PR DESCRIPTION
Imports recipes from webOS-ports:
- https://github.com/webOS-ports/meta-webos-ports/blob/hardknott/meta-luneos/recipes-support/bluebinder/bluebinder.bb
- https://github.com/webOS-ports/meta-webos-ports/blob/hardknott/meta-luneos/recipes-support/libglibutil/libglibutil.bb
- https://github.com/webOS-ports/meta-webos-ports/blob/hardknott/meta-luneos/recipes-support/libgbinder/libgbinder.bb 

Slightly adjusted to run for AsteroidOS based watches.