### PR TITLE
ttf-asteroid-fonts: Use Twemoji emoji fonts.

### DIFF
--- a/recipes-graphics/ttf-fonts/ttf-asteroid-fonts/69-emoji.conf
+++ b/recipes-graphics/ttf-fonts/ttf-asteroid-fonts/69-emoji.conf
@@ -11,21 +11,21 @@
     <alias binding="weak">
         <family>sans-serif</family>
         <prefer>
-            <family>emoji</family>
+            <family>Twemoji</family>
         </prefer>
     </alias>
 
     <alias binding="weak">
         <family>serif</family>
         <prefer>
-            <family>emoji</family>
+            <family>Twemoji</family>
         </prefer>
     </alias>
 
     <alias binding="weak">
         <family>monospace</family>
         <prefer>
-            <family>emoji</family>
+            <family>Twemoji</family>
         </prefer>
     </alias>
 </fontconfig>

--- a/recipes-graphics/ttf-fonts/ttf-asteroid-fonts_git.bb
+++ b/recipes-graphics/ttf-fonts/ttf-asteroid-fonts_git.bb
@@ -1,8 +1,8 @@
 SUMMARY = "AsteroidOS fonts set"
 SECTION = "fonts"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-fonts"
-LICENSE = "OFL-1.1 & Apache-2.0 & CC-BY-3.0"
-LIC_FILES_CHKSUM = "file://README.md;beginline=6;endline=15;md5=6ca7f8b58e9d2f7faf16259f81816ed5"
+LICENSE = "OFL-1.1 & Apache-2.0 & CC-BY-3.0 & CC-BY-4.0 & MIT"
+LIC_FILES_CHKSUM = "file://README.md;beginline=6;endline=18;md5=988d871903434a93789ff6e955fa5f8e"
 PR = "r0"
 INHIBIT_DEFAULT_DEPS = "1"
 
@@ -12,6 +12,8 @@ inherit fontcache
 SRC_URI = "git://github.com/AsteroidOS/asteroid-fonts.git;protocol=https \
     file://69-emoji.conf"
 SRCREV = "${AUTOREV}"
+PR = "r1"
+PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 FONT_PACKAGES = "ttf-asteroid-fonts"


### PR DESCRIPTION
Replace the current emoji fonts with the Twitter emoji fonts. They suit better to the _flat_ design that AsteroidOS uses.

| Before | After |
|----------|--------|
| ![Screenshot_20211125_191126](https://user-images.githubusercontent.com/7857908/143492953-12c91a04-3562-4389-aced-c2d20263c4c0.jpg) | ![Screenshot_20211125_202253](https://user-images.githubusercontent.com/7857908/143492955-4ecde500-0755-4584-b33e-8dfc524597e5.jpg) |


Relevant other PR: https://github.com/AsteroidOS/asteroid-fonts/pull/2