### PR TITLE
Add Diamonds game to stock images.

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -7,7 +7,7 @@ IMAGE_FEATURES += "package-management debug-tweaks"
 IMAGE_INSTALL += " \
 kernel-modules base-files base-passwd systemd busybox iproute2 connman pam-plugin-loginuid bluez5 pulseaudio-server openssh-sshd openssh-sftp-server openssh-scp statefs dsme mce ngfd timed sensorfw android-init resize-rootfs mapplauncherd-booster-qtcomponents usb-moded ofono \
 ${@oe.utils.conditional('MACHINE_HAS_WLAN', 'true', 'iproute2 wpa-supplicant connman-client', '', d)} \
-qtgraphicaleffects-qmlplugins supported-languages ttf-asteroid-fonts asteroid-launcher asteroid-calculator asteroid-calendar asteroid-stopwatch asteroid-settings asteroid-timer asteroid-alarmclock asteroid-weather asteroid-music asteroid-btsyncd asteroid-flashlight"
+qtgraphicaleffects-qmlplugins supported-languages ttf-asteroid-fonts asteroid-launcher asteroid-calculator asteroid-calendar asteroid-stopwatch asteroid-settings asteroid-timer asteroid-alarmclock asteroid-weather asteroid-music asteroid-btsyncd asteroid-flashlight asteroid-diamonds"
 
 EXTRA_USERS_PARAMS = "groupadd system; \
                       groupadd statefs; \

--- a/recipes-asteroid/asteroid-diamonds/asteroid-diamonds_git.bb
+++ b/recipes-asteroid/asteroid-diamonds/asteroid-diamonds_git.bb
@@ -1,0 +1,16 @@
+SUMMARY = "A 2048 like game for AsteroidOS"
+HOMEPAGE = "https://github.com/AsteroidOS/asteroid-diamonds.git"
+LICENSE = "GPLv3"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
+
+SRC_URI = "git://github.com/AsteroidOS/asteroid-diamonds.git;protocol=https"
+SRCREV = "${AUTOREV}"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+inherit cmake_qt5
+
+FILES:${PN} += "/usr/share/icons/asteroid/"
+FILES:${PN} += "/usr/share/translations/"
+
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"


### PR DESCRIPTION
This PR adds the 2048 game to stock AsteroidOS images.
During the past few days many changes were made to the original 2048 game for AsteroidOS.

Thanks to great help from @eLtMosen and others from the matrix chat group we came up with the design shown in the image below.

One remark I have to make is that the name of the app will result it being the first entry in the app launcher. In my opinion this isn't very desirable. So instead I propose to change the name to: `asteroid-diamonds` as the current game rotated the grid by 45 degrees to create a diamond shape. This has the benefit of the game not being the first entry in the list and also it gives it a unique name because the game doesn't look identical to a 2048 clone anymore.

Obviously, before merging we need to also move the repo (https://github.com/MagneFire/asteroid-2048/tree/devel) under the AsteroidOS umbrella. So the code for that one probably also could benefit some reviewing.

![](https://github.com/MagneFire/asteroid-2048/raw/devel/screenshot.png)

Opinions on whether to include this game to stock images are also welcome :smile:


Relevant other PR: https://github.com/AsteroidOS/meta-asteroid-community/pull/7