### PR TITLE
Replace i586 with core2-32

### DIFF
--- a/conf/distro/asteroid.conf
+++ b/conf/distro/asteroid.conf
@@ -38,6 +38,6 @@ FILESYSTEM_PERMS_TABLES = "files/fs-perms.txt files/asteroidos-fs-perms.txt"
 
 PACKAGE_FEED_URIS = "https://release.asteroidos.org/nightlies/"
 PACKAGE_FEED_BASE_PATHS = "ipk"
-PACKAGE_FEED_ARCHS = "all anthias armv7vehf-neon bass dory i586 lenok qemux86 sparrow sprat sturgeon swift tetra wren"
+PACKAGE_FEED_ARCHS = "all anthias armv7vehf-neon bass core2-32 dory lenok qemux86 sparrow sprat sturgeon swift tetra wren"
 
 SKIP_META_GNOME_SANITY_CHECK = "1"


### PR DESCRIPTION
Fix bug #80 by replacing i586 with core2-32.  This fixes the
problem of missing i586 directory in generated nightly ipks
and provides the qemux86 target with a correct path for opkg.

Signed-off-by: Ed Beroset <beroset@ieee.org>