### PR TITLE
libhybris: Fix compilation.

### DIFF
--- a/recipes-core/libhybris/libhybris_git.bbappend
+++ b/recipes-core/libhybris/libhybris_git.bbappend
@@ -5,3 +5,7 @@ DEPENDS:append = " wayland "
 EXTRA_OECONF:append = " --enable-wayland --with-default-egl-platform=wayland --with-default-hybris-ld-library-path=/usr/libexec/hal-droid/system/lib:/vendor/lib:/system/lib"
 
 COMPATIBLE_MACHINE=""
+
+do_configure:prepend() {
+    sed -i "s@=\`\$PKG_CONFIG@=\$\{PKG_CONFIG_SYSROOT_DIR\}\`\$PKG_CONFIG@" ${S}/configure.ac
+}


### PR DESCRIPTION
libhybris uses pkgconfig to get the prefix for the wayland-scanner. Unfortunally this causes it to use: /usr/bin/wayland-scanner (host tool!).
We don't want this to happen, instead patch it so that it uses wayland-scanner from the sysroot.

~Additionally move the applying of the other two patches to here too. It should not be needed to apply this separately for every watch. Instead a watch can just clear the patches required for a 'new' libhybris build.~ Bad choice because it's not easy to clear all patches used!


I'll need to undo the above