### PR TITLE
Close psplash before starting asteroid-launcher.

### DIFF
--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher/asteroid-launcher.service
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher/asteroid-launcher.service
@@ -7,6 +7,7 @@ ConditionUser=!root
 Type=notify
 EnvironmentFile=-/var/lib/environment/compositor/*.conf
 ExecStartPre=/bin/sh -ec 'while [ ! -f /dev/.coldboot_done ]; do sleep 1; done'
+ExecStartPre=/bin/sh -ec '/bin/echo QUIT > /run/psplash_fifo'
 ExecStart=/usr/bin/asteroid-launcher $LIPSTICK_OPTIONS --systemd
 TimeoutStopSec=3
 Restart=always

--- a/recipes-core/initrdscripts/initramfs-scripts-android/init.sh
+++ b/recipes-core/initrdscripts/initramfs-scripts-android/init.sh
@@ -130,6 +130,11 @@ umount -l /proc
 umount -l /sys
 mount -t proc proc $BOOT_DIR/proc
 mount -t sysfs sys $BOOT_DIR/sys
+mount -t tmpfs run $BOOT_DIR/run
+
+echo FIFO $BOOT_DIR/run > /run/psplash_fifo
+# We need to give psplash time to create the new named pipe.
+sleep 1
 
 info "Switching to rootfs..."
 exec switch_root -c /dev/ttyprintk $BOOT_DIR /lib/systemd/systemd

--- a/recipes-core/psplash/files/0002-psplash-Allow-for-moving-the-named-pipe.patch
+++ b/recipes-core/psplash/files/0002-psplash-Allow-for-moving-the-named-pipe.patch
@@ -1,0 +1,106 @@
+From 3a92bdb69745c1ba0385f17e82b86eb8e2e81efb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Sun, 6 Feb 2022 19:13:12 +0100
+Subject: [PATCH] psplash: Allow for moving the named pipe.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ psplash.c | 65 ++++++++++++++++++++++++++++++++++---------------------
+ 1 file changed, 40 insertions(+), 25 deletions(-)
+
+diff --git a/psplash.c b/psplash.c
+index 011e3ab..0c04cc0 100644
+--- a/psplash.c
++++ b/psplash.c
+@@ -130,6 +130,15 @@ parse_command (PSplashFB *fb, char *string)
+     {
+       return 1;
+     }
++  else if (!strcmp(command,"FIFO")) 
++    {
++      char *arg = strtok(NULL, "\0");
++
++      if (arg) {
++        setenv("PSPLASH_FIFO_DIR", arg, 1);
++      }
++      return 1;
++    }
+ #ifdef PSPLASH_ENABLE_ANIMATED_GIF
+ 	else if (!strcmp(command, "ALIVE"))
+ 	{
+@@ -332,30 +341,6 @@ main (int argc, char** argv)
+ 		exit(-1);
+ #endif
+ 
+-  rundir = getenv("PSPLASH_FIFO_DIR");
+-
+-  if (!rundir)
+-    rundir = "/run";
+-
+-  chdir(rundir);
+-
+-  if (mkfifo(PSPLASH_FIFO, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP))
+-    {
+-      if (errno!=EEXIST) 
+-	    {
+-	      perror("mkfifo");
+-	      exit(-1);
+-	    }
+-    }
+-
+-  pipe_fd = open (PSPLASH_FIFO,O_RDONLY|O_NONBLOCK);
+-  
+-  if (pipe_fd==-1) 
+-    {
+-      perror("pipe open");
+-      exit(-2);
+-    }
+-
+   if (!disable_console_switch)
+     psplash_console_switch ();
+ 
+@@ -420,7 +405,37 @@ main (int argc, char** argv)
+ 	psplash_alive_init();
+ #endif
+ 
+-  psplash_main (fb, pipe_fd, 0);
++  // Override default masking of S_IWGRP | S_IWOTH
++  // This is needed so that any user can stop psplash.
++  umask(0);
++
++  do {
++    rundir = getenv("PSPLASH_FIFO_DIR");
++
++    if (!rundir)
++      rundir = "/run";
++
++    chdir(rundir);
++
++    if (mkfifo(PSPLASH_FIFO, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH))
++      {
++        if (errno!=EEXIST) 
++        {
++          perror("mkfifo");
++          exit(-1);
++        }
++      }
++
++    pipe_fd = open (PSPLASH_FIFO,O_RDONLY|O_NONBLOCK);
++    
++    if (pipe_fd==-1) 
++      {
++        perror("pipe open");
++        exit(-2);
++      }
++
++    psplash_main (fb, pipe_fd, 0);
++  } while (strcmp(rundir, getenv("PSPLASH_FIFO_DIR")));
+ 
+ #ifdef PSPLASH_ENABLE_ANIMATED_GIF
+ 	psplash_alive_destroy();
+-- 
+2.35.1
+

--- a/recipes-core/psplash/psplash_git.bbappend
+++ b/recipes-core/psplash/psplash_git.bbappend
@@ -4,6 +4,7 @@ SRC_URI += "file://psplash-colors.h \
             file://psplash-bar-img.png \
             file://psplash-config.h \
             file://0001-Add-alive-animated-GIF-support.patch \
+            file://0002-psplash-Allow-for-moving-the-named-pipe.patch \
             file://psplash-img-280-154.gif \
             file://psplash-img-320-176.gif \
             file://psplash-img-400-220.gif \


### PR DESCRIPTION
This adds the necessary parts to allow the `ceres` user to stop `psplash`.
`psplash` exposes a `/run/psplash_fifo` (named pipe) in the ramdisk. This can be used to quit `psplash` by means of the command: `echo QUIT > /run/psplash_fifo`. This is however limited to the ramdisk. We need some way to transfer this named pipe to the new root. So that we can properly quit `psplash`.
This is achieved by adding a `FIFO` command that takes a new root. This allows for displaying the boot logo while transferring control to the new root.


This fixes https://github.com/AsteroidOS/asteroid/issues/180 and possibly https://github.com/AsteroidOS/asteroid/issues/191 too (needs a bit more testing).