### PR TITLE
asteroid-launcher: Distribute the asteroid-launcher package as machine specific.

### DIFF
--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bb
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bb
@@ -2,6 +2,7 @@ SUMMARY = "Asteroid's launcher based on lipstick"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-launcher"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://qml/MainScreen.qml;beginline=1;endline=29;md5=3d250dd089f5d6221d9054029963e332"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-launcher.git;protocol=https \
     file://asteroid-launcher.service \


### PR DESCRIPTION
Every watch defines their own set of input devices for the touchscreen and/or other input.
This makes the package machine specific, we cannot distribute this package identically for all watches (armv7vehf-neon).

This issue has been reported in the past but came back to my mind after @beroset mentioned this issue again (Thanks!). 