### PR TITLE
asteroid-machine-config: Regenerate config file when machine variables change.

### DIFF
--- a/recipes-asteroid/asteroid-machine-config/asteroid-machine-config_1.0.bb
+++ b/recipes-asteroid/asteroid-machine-config/asteroid-machine-config_1.0.bb
@@ -4,10 +4,16 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+def display_variables(d):
+    return ["MACHINE_DISPLAY_FLAT_TIRE", "MACHINE_DISPLAY_BORDER_GESTURE_WIDTH", "MACHINE_DISPLAY_ROUND", "MACHINE_NEEDS_BURN_IN_PROTECTION"]
+
+def capability_variables(d):
+    return ["MACHINE_HAS_WLAN", "MACHINE_HAS_SPEAKER"]
+
 python do_generate_config () {
     machine_vars = {
-        "Display": ["MACHINE_DISPLAY_FLAT_TIRE", "MACHINE_DISPLAY_BORDER_GESTURE_WIDTH", "MACHINE_DISPLAY_ROUND", "MACHINE_NEEDS_BURN_IN_PROTECTION"],
-        "Capabilities": ["MACHINE_HAS_WLAN", "MACHINE_HAS_SPEAKER"]
+        "Display": display_variables(d),
+        "Capabilities": capability_variables(d)
     }
 
     from configparser import ConfigParser
@@ -32,6 +38,13 @@ do_install:append() {
     install -m 644 ${WORKDIR}/machine.conf ${D}/etc/asteroid/machine.conf
 }
 
+def machine_variables(d):
+    variables = []
+    variables.extend(display_variables(d))
+    variables.extend(capability_variables(d))
+    return " ".join(variables)
+
+do_generate_config[vardeps] += "${@machine_variables(d)}"
 addtask do_generate_config before do_install
 
 FILES:${PN} += "/etc/asteroid/"

--- a/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
+++ b/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
@@ -11,7 +11,7 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 inherit cmake_qt5
 
-DEPENDS += "extra-cmake-modules asteroid-machine-config qtdeclarative qtsvg qtvirtualkeyboard mlite mapplauncherd-booster-qtcomponents qtdeclarative-native"
+DEPENDS += "extra-cmake-modules qtdeclarative qtsvg qtvirtualkeyboard mlite mapplauncherd-booster-qtcomponents qtdeclarative-native"
 RDEPENDS:${PN} += "asteroid-machine-config qtsvg-plugins qtvirtualkeyboard asteroid-icons-ion"
 
 FILES:${PN} += "/usr/lib /usr/share/icons/asteroid/"


### PR DESCRIPTION
Additionally, this removes asteroid-machine-config from the build time dependencies (it's only a runtime dependency). This improves build times as asteroid apps don't need rebuilding every time a machine variable changes (which was the entire reason for this thing's existence :wink: )