### PR TITLE
asteroid-launcher: Set working directory to fix graphics related warning.

### DIFF
--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher/asteroid-launcher.service
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher/asteroid-launcher.service
@@ -5,6 +5,7 @@ ConditionUser=!root
 
 [Service]
 Type=notify
+WorkingDirectory=/
 EnvironmentFile=-/var/lib/environment/compositor/*.conf
 ExecStartPre=/bin/sh -ec 'while [ ! -f /dev/.coldboot_done ]; do sleep 1; done'
 ExecStartPre=-/bin/sh -ec '/bin/echo QUIT > /run/psplash_fifo'


### PR DESCRIPTION
The HWComposer on various watches tries to access 'sys/class/graphics/fb0/dyn_pu'.
Notice the missing / in front of sys. This makes it behave so that the path is only accessible when the compositor is started from the root directory.

Fixes this logcat warning: Failed to open sysfs node: sys/class/graphics/fb0/dyn_pu.
