### PR TITLE
Add support for Kirkstone.

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -1,6 +1,6 @@
 inherit core-image
 inherit extrausers
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 
 IMAGE_FEATURES += "package-management debug-tweaks"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,6 +8,6 @@ BBFILE_COLLECTIONS += "asteroid-layer"
 BBFILE_PATTERN_asteroid-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_asteroid-layer = "7"
 
-LAYERSERIES_COMPAT_asteroid-layer = "honister"
+LAYERSERIES_COMPAT_asteroid-layer = "kirkstone"
 
 PACKAGE_FEED += "gdb strace"

--- a/recipes-android/brcm-patchram-plus/brcm-patchram-plus_git.bbappend
+++ b/recipes-android/brcm-patchram-plus/brcm-patchram-plus_git.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/brcm-patchram-plus:"
 SRC_URI:append= " file://patchram.service"
-LICENSE = "BSD"
+LICENSE = "Apache-2.0"
 
 SRC_URI = "git://github.com/AsteroidOS/brcm-patchram-plus.git;protocol=https;branch=master"
 S = "${WORKDIR}/git"

--- a/recipes-android/brcm-patchram-plus/brcm-patchram-plus_git.bbappend
+++ b/recipes-android/brcm-patchram-plus/brcm-patchram-plus_git.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/brcm-patchram-plus:"
 SRC_URI:append= " file://patchram.service"
 LICENSE = "BSD"
 
-SRC_URI = "git://github.com/AsteroidOS/brcm-patchram-plus.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/brcm-patchram-plus.git;protocol=https;branch=master"
 S = "${WORKDIR}/git"
 SRCREV = "94fb127e614b19a9a95561b8c1a0716e2e1e6293"
 

--- a/recipes-android/droidmedia/droidmedia_git.bb
+++ b/recipes-android/droidmedia/droidmedia_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://droidmedia.h;beginline=1;endline=18;md5=0500d15dde64c
 
 inherit meson pkgconfig
 
-SRC_URI = "git://github.com/sailfishos/droidmedia.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/droidmedia.git;protocol=https;branch=master"
 SRCREV = "8829b9dcd3b67ea6ea75a5fe17c408d79fb17bc5"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-alarmclock/asteroid-alarmclock_git.bb
+++ b/recipes-asteroid/asteroid-alarmclock/asteroid-alarmclock_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-alarmclock.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-alarmclock.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-alarmclock.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-alarmclock/asteroid-alarmclock_git.bb
+++ b/recipes-asteroid/asteroid-alarmclock/asteroid-alarmclock_git.bb
@@ -8,7 +8,7 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit cmake_qt5
+inherit cmake_qt5 pkgconfig
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native nemo-qml-plugin-alarms qttools-native qtdeclarative-native"
 RDEPENDS:${PN} += "nemo-qml-plugin-alarms"

--- a/recipes-asteroid/asteroid-alarmclock/asteroid-alarmclock_git.bb
+++ b/recipes-asteroid/asteroid-alarmclock/asteroid-alarmclock_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's alarm clock app"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-alarmclock.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-alarmclock.git;protocol=https;branch=master"

--- a/recipes-asteroid/asteroid-btsyncd/asteroid-btsyncd_git.bb
+++ b/recipes-asteroid/asteroid-btsyncd/asteroid-btsyncd_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's BLE synchronization daemon."
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-btsyncd"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-btsyncd.git;protocol=https;branch=master \

--- a/recipes-asteroid/asteroid-btsyncd/asteroid-btsyncd_git.bb
+++ b/recipes-asteroid/asteroid-btsyncd/asteroid-btsyncd_git.bb
@@ -9,7 +9,7 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit cmake_qt5 gsettings
+inherit cmake_qt5 gsettings pkgconfig
 
 DEPENDS += "qml-asteroid qtbase glibmm qtmpris timed qttools-native nemo-qml-plugin-systemsettings"
 RDEPENDS:${PN} += "glibmm qtmpris"

--- a/recipes-asteroid/asteroid-btsyncd/asteroid-btsyncd_git.bb
+++ b/recipes-asteroid/asteroid-btsyncd/asteroid-btsyncd_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-btsyncd"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-btsyncd.git;protocol=https \
+SRC_URI = "git://github.com/AsteroidOS/asteroid-btsyncd.git;protocol=https;branch=master \
     file://asteroid-btsyncd.service"
 SRCREV = "${AUTOREV}"
 PR = "r1"

--- a/recipes-asteroid/asteroid-calculator/asteroid-calculator_git.bb
+++ b/recipes-asteroid/asteroid-calculator/asteroid-calculator_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's calculator app"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-calculator.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-calculator.git;protocol=https;branch=master"

--- a/recipes-asteroid/asteroid-calculator/asteroid-calculator_git.bb
+++ b/recipes-asteroid/asteroid-calculator/asteroid-calculator_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-calculator.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-calculator.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-calculator.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-calendar/asteroid-calendar_git.bb
+++ b/recipes-asteroid/asteroid-calendar/asteroid-calendar_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-calendar.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-calendar.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-calendar.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-calendar/asteroid-calendar_git.bb
+++ b/recipes-asteroid/asteroid-calendar/asteroid-calendar_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's calendar app"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-calendar.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-calendar.git;protocol=https;branch=master"

--- a/recipes-asteroid/asteroid-camera/asteroid-camera_git.bb
+++ b/recipes-asteroid/asteroid-camera/asteroid-camera_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's camera app"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-camera.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-camera.git;protocol=https;branch=master"

--- a/recipes-asteroid/asteroid-camera/asteroid-camera_git.bb
+++ b/recipes-asteroid/asteroid-camera/asteroid-camera_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-camera.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-camera.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-camera.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-compass/asteroid-compass_git.bb
+++ b/recipes-asteroid/asteroid-compass/asteroid-compass_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-compass.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-compass.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-compass.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-compass/asteroid-compass_git.bb
+++ b/recipes-asteroid/asteroid-compass/asteroid-compass_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's compass app"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-compass.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-compass.git;protocol=https;branch=master"

--- a/recipes-asteroid/asteroid-diamonds/asteroid-diamonds_git.bb
+++ b/recipes-asteroid/asteroid-diamonds/asteroid-diamonds_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-diamonds.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-diamonds.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-diamonds.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-diamonds/asteroid-diamonds_git.bb
+++ b/recipes-asteroid/asteroid-diamonds/asteroid-diamonds_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "A 2048 like game for AsteroidOS"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-diamonds.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-diamonds.git;protocol=https;branch=master"

--- a/recipes-asteroid/asteroid-flashlight/asteroid-flashlight_git.bb
+++ b/recipes-asteroid/asteroid-flashlight/asteroid-flashlight_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-flashlight.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-flashlight.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-flashlight.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-flashlight/asteroid-flashlight_git.bb
+++ b/recipes-asteroid/asteroid-flashlight/asteroid-flashlight_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's flashlight app"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-flashlight.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-flashlight.git;protocol=https;branch=master"

--- a/recipes-asteroid/asteroid-gps/asteroid-gps_git.bb
+++ b/recipes-asteroid/asteroid-gps/asteroid-gps_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-gps-test.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-gps-test.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-gps-test.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-gps/asteroid-gps_git.bb
+++ b/recipes-asteroid/asteroid-gps/asteroid-gps_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's GPS test app"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-gps-test.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-gps-test.git;protocol=https;branch=master"

--- a/recipes-asteroid/asteroid-hrm/asteroid-hrm_git.bb
+++ b/recipes-asteroid/asteroid-hrm/asteroid-hrm_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-hrm.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-hrm.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-hrm.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-hrm/asteroid-hrm_git.bb
+++ b/recipes-asteroid/asteroid-hrm/asteroid-hrm_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's heart rate monitor app"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-hrm.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-hrm.git;protocol=https;branch=master"

--- a/recipes-asteroid/asteroid-icons/asteroid-icons-ion_git.bb
+++ b/recipes-asteroid/asteroid-icons/asteroid-icons-ion_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-icons-ion"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=92e02b7236a0635eaf1478f8041b0602"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-icons-ion;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-icons-ion;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bb
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's launcher based on lipstick"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-launcher"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://qml/MainScreen.qml;beginline=1;endline=29;md5=3d250dd089f5d6221d9054029963e332"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 

--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bb
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bb
@@ -12,7 +12,7 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 DEPENDS += "lipstick qttools-native timed"
 RDEPENDS:${PN} += "qtdeclarative-qmlplugins qml-asteroid mce-qt5 qtwayland-plugins nemo-qml-plugin-time nemo-qml-plugin-configuration asteroid-wallpapers"

--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bb
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://qml/MainScreen.qml;beginline=1;endline=29;md5=3d250dd089f5d6221d9054029963e332"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-launcher.git;protocol=https \
+SRC_URI = "git://github.com/AsteroidOS/asteroid-launcher.git;protocol=https;branch=master \
     file://asteroid-launcher.service \
     file://default.conf"
 SRC_URI:append:qemux86 = " file://qemu.conf file://kms-qemu.json"

--- a/recipes-asteroid/asteroid-machine-config/asteroid-machine-config_1.0.bb
+++ b/recipes-asteroid/asteroid-machine-config/asteroid-machine-config_1.0.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Generates a machine specific config file for AsteroidOS"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-asteroid/asteroid-music/asteroid-music_git.bb
+++ b/recipes-asteroid/asteroid-music/asteroid-music_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's music app"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-music.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-music.git;protocol=https;branch=master"

--- a/recipes-asteroid/asteroid-music/asteroid-music_git.bb
+++ b/recipes-asteroid/asteroid-music/asteroid-music_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-music.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-music.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-music.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
+++ b/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
@@ -8,7 +8,7 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit cmake_qt5
+inherit cmake_qt5 pkgconfig
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus qttools-native qtdeclarative-native"
 RDEPENDS:${PN} += "nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus qtmultimedia-qmlplugins libconnman-qt5-qmlplugins"

--- a/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
+++ b/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-settings.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-settings.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-settings.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
+++ b/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's system settings app"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-settings.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-settings.git;protocol=https;branch=master"

--- a/recipes-asteroid/asteroid-stopwatch/asteroid-stopwatch_git.bb
+++ b/recipes-asteroid/asteroid-stopwatch/asteroid-stopwatch_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-stopwatch.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-stopwatch.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-stopwatch.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-stopwatch/asteroid-stopwatch_git.bb
+++ b/recipes-asteroid/asteroid-stopwatch/asteroid-stopwatch_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's stopwatch app"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-stopwatch.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-stopwatch.git;protocol=https;branch=master"

--- a/recipes-asteroid/asteroid-timer/asteroid-timer_git.bb
+++ b/recipes-asteroid/asteroid-timer/asteroid-timer_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's timer app"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-timer.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-timer.git;protocol=https;branch=master"

--- a/recipes-asteroid/asteroid-timer/asteroid-timer_git.bb
+++ b/recipes-asteroid/asteroid-timer/asteroid-timer_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-timer.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-timer.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-timer.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-wallpapers/asteroid-wallpapers_git.bb
+++ b/recipes-asteroid/asteroid-wallpapers/asteroid-wallpapers_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-wallpapers"
 LICENSE = "CC-BY-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE_CCBY;md5=e5ae8a8ac3605e6baffcd72982f4703b"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-wallpapers;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-wallpapers;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-weather/asteroid-weather_git.bb
+++ b/recipes-asteroid/asteroid-weather/asteroid-weather_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/asteroid-weather.git"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-weather.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/asteroid-weather.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/asteroid-weather/asteroid-weather_git.bb
+++ b/recipes-asteroid/asteroid-weather/asteroid-weather_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Asteroid's weather app"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-weather.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-weather.git;protocol=https;branch=master"

--- a/recipes-asteroid/qml-asteroid/asteroid-generate-desktop-native_git.bb
+++ b/recipes-asteroid/qml-asteroid/asteroid-generate-desktop-native_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Desktop file generation for AsteroidOS apps"
 HOMEPAGE = "https://github.com/AsteroidOS/qml-asteroid.git"
-LICENSE = "LGPL-2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=1702a92c723f09e3fab3583b165a8d90"
 
 SRC_URI = "git://github.com/AsteroidOS/qml-asteroid.git;protocol=https;branch=master"

--- a/recipes-asteroid/qml-asteroid/asteroid-generate-desktop-native_git.bb
+++ b/recipes-asteroid/qml-asteroid/asteroid-generate-desktop-native_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/qml-asteroid.git"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=1702a92c723f09e3fab3583b165a8d90"
 
-SRC_URI = "git://github.com/AsteroidOS/qml-asteroid.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/qml-asteroid.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
+++ b/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
@@ -9,7 +9,7 @@ SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit cmake_qt5
+inherit cmake_qt5 pkgconfig
 
 DEPENDS += "extra-cmake-modules qtdeclarative qtsvg qtvirtualkeyboard mlite mapplauncherd-booster-qtcomponents qtdeclarative-native"
 RDEPENDS:${PN} += "asteroid-machine-config qtsvg-plugins qtvirtualkeyboard asteroid-icons-ion"

--- a/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
+++ b/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML components for AsteroidOS"
 HOMEPAGE = "https://github.com/AsteroidOS/qml-asteroid.git"
-LICENSE = "LGPL-2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=1702a92c723f09e3fab3583b165a8d90"
 
 SRC_URI = "git://github.com/AsteroidOS/qml-asteroid.git;protocol=https;branch=master"

--- a/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
+++ b/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/qml-asteroid.git"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=1702a92c723f09e3fab3583b165a8d90"
 
-SRC_URI = "git://github.com/AsteroidOS/qml-asteroid.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/qml-asteroid.git;protocol=https;branch=master"
 SRC_URI:append:qemux86 = " file://0001-Spinners-Disable-shaders-which-cause-all-sorts-of-pr.patch"
 SRCREV = "${AUTOREV}"
 PR = "r1"

--- a/recipes-asteroid/supported-languages/supported-languages_git.bb
+++ b/recipes-asteroid/supported-languages/supported-languages_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/AsteroidOS/supported-languages"
 LICENSE = "CC0-1.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=65d3616852dbf7b1a6d4b53b00626032"
 
-SRC_URI = "git://github.com/AsteroidOS/supported-languages.git;protocol=https \
+SRC_URI = "git://github.com/AsteroidOS/supported-languages.git;protocol=https;branch=master \
     file://locale.conf \
     file://localeEnv.conf"
 SRCREV = "${AUTOREV}"

--- a/recipes-connectivity/ofono/ofono_%.bbappend
+++ b/recipes-connectivity/ofono/ofono_%.bbappend
@@ -1,5 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/ofono:"
-SRC_URI = "git://github.com/rilmodem/ofono;protocol=https \
+SRC_URI = "git://github.com/rilmodem/ofono;protocol=https;branch=master \
            file://ofono.service \
            file://ofono \
            file://use-python3.patch \

--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,3 +1,1 @@
 PACKAGECONFIG:remove = "rng-tools"
-
-EXTRA_OECONF:append = " --with-sandbox=rlimit"

--- a/recipes-connectivity/telepathy/telepathy-farstream_git.bb
+++ b/recipes-connectivity/telepathy/telepathy-farstream_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://telepathy.freedesktop.org/wiki/Components/Telepathy-Farstrea
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2071c52746eb125b27a40421186f5d80"
 
-SRC_URI = "git://anongit.freedesktop.org/git/telepathy/telepathy-farstream.git;protocol=https \
+SRC_URI = "git://anongit.freedesktop.org/git/telepathy/telepathy-farstream.git;protocol=https;branch=master \
            file://0001-Disable-introspection-and-gtk-doc.patch"
 SRCREV = "cd5910078b9d8f46fa411c093895d5f73432779b"
 PR = "r1"

--- a/recipes-connectivity/telepathy/telepathy-farstream_git.bb
+++ b/recipes-connectivity/telepathy/telepathy-farstream_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "telepathy-farstream is a GObject-based C library that uses Telepathy GLib, Farstream and GStreamer to handle the media streaming part of channels of type Call"
 
 HOMEPAGE = "https://telepathy.freedesktop.org/wiki/Components/Telepathy-Farstream/"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2071c52746eb125b27a40421186f5d80"
 
 SRC_URI = "git://anongit.freedesktop.org/git/telepathy/telepathy-farstream.git;protocol=https;branch=master \

--- a/recipes-connectivity/telepathy/telepathy-qt_git.bb
+++ b/recipes-connectivity/telepathy/telepathy-qt_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Telepathy-Qt is a Qt high-level binding for Telepathy"
 HOMEPAGE = "https://telepathy.freedesktop.org/doc/telepathy-qt/"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
 SRC_URI = "git://anongit.freedesktop.org/git/telepathy/telepathy-qt.git;protocol=https;branch=master \

--- a/recipes-connectivity/telepathy/telepathy-qt_git.bb
+++ b/recipes-connectivity/telepathy/telepathy-qt_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://telepathy.freedesktop.org/doc/telepathy-qt/"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
-SRC_URI = "git://anongit.freedesktop.org/git/telepathy/telepathy-qt.git;protocol=https \
+SRC_URI = "git://anongit.freedesktop.org/git/telepathy/telepathy-qt.git;protocol=https;branch=master \
            file://0001-Don-t-require-QtGui.patch \
            file://0002-Don-t-require-python.patch \
            file://0003-Disable-examples-compilation.patch \

--- a/recipes-core/bluebinder/bluebinder.bb
+++ b/recipes-core/bluebinder/bluebinder.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Simple proxy for using Android binder based bluetooth through vhc
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://bluebinder.c;beginline=1;endline=27;md5=430727b8efeca344ab89eeb635b4fa79"
 
-SRC_URI = "git://github.com/mer-hybris/bluebinder.git \
+SRC_URI = "git://github.com/mer-hybris/bluebinder.git;branch=master;protocol=https \
            file://0001-Use-CC-as-compiler.patch \
 "
 SRCREV = "419ab4a36fd61f841e7b1070b92b5e23ea813b63"

--- a/recipes-core/bluebinder/bluebinder.bb
+++ b/recipes-core/bluebinder/bluebinder.bb
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Christophe Chapuis <chris.chapuis@gmail.com>
 
 DESCRIPTION = "Simple proxy for using Android binder based bluetooth through vhci."
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://bluebinder.c;beginline=1;endline=27;md5=430727b8efeca344ab89eeb635b4fa79"
 
 SRC_URI = "git://github.com/mer-hybris/bluebinder.git;branch=master;protocol=https \

--- a/recipes-core/firmwared/firmwared_git.bb
+++ b/recipes-core/firmwared/firmwared_git.bb
@@ -3,7 +3,7 @@ DEPENDS += "udev glib-2.0"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE-APACHE;md5=7b486c2338d225a1405d979ed2c15ce8"
 
-SRC_URI = "git://github.com/teg/firmwared;protocol=https \
+SRC_URI = "git://github.com/teg/firmwared;protocol=https;branch=master \
            file://firmwared.service"
 SRCREV = "2e6b5db43d63a5c0283a4cae9a6a20b7ad107a04"
 S = "${WORKDIR}/git"

--- a/recipes-core/lcd-tools/lcd-tools.bb
+++ b/recipes-core/lcd-tools/lcd-tools.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Daemon backend to control LCD functions"
 HOMEPAGE = "https://github.com/AsteroidOS/lcd-tools.git"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 

--- a/recipes-core/libgbinder/libgbinder.bb
+++ b/recipes-core/libgbinder/libgbinder.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Library used to interact with Android's binder module."
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=24f23d12bbc59c7e5ab483c52a172555"
 
-SRC_URI = "git://github.com/mer-hybris/libgbinder.git \
+SRC_URI = "git://github.com/mer-hybris/libgbinder.git;branch=master;protocol=https \
            file://gbinder.conf \
 "
 SRCREV = "88df2edb9533fc4680fe59f3113f839d0cf9c77a"

--- a/recipes-core/libglibutil/libglibutil.bb
+++ b/recipes-core/libglibutil/libglibutil.bb
@@ -5,7 +5,7 @@ LICENSE = "BSD-3-Clause"
 SECTION = "webos/support"
 LIC_FILES_CHKSUM = "file://src/gutil_log.c;beginline=1;endline=31;md5=c476c5938ec00208b29c1c1743b4a006"
 
-SRC_URI = "git://github.com/sailfishos/libglibutil.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/libglibutil.git;protocol=https;branch=master"
 SRCREV = "dfcf23805b49307e63d1090aec69255de4a167ea"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-core/msm-fb-refresher/msm-fb-refresher_git.bb
+++ b/recipes-core/msm-fb-refresher/msm-fb-refresher_git.bb
@@ -3,7 +3,7 @@ PR = "r0"
 SRC_URI = "git://github.com/AsteroidOS/msm-fb-refresher.git;protocol=https;branch=master \
     file://msm-fb-refresher.service"
 SRCREV = "b89cca860f9c37e71b3fbd5ae53c4e8d521e1de8"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://refresher.c;beginline=1;endline=16;md5=3d0eae401b24b819f25959dcfcc3194f"
 S = "${WORKDIR}/git"
 PACKAGE_DEBUG_SPLIT_STYLE = "debug-without-src"

--- a/recipes-core/msm-fb-refresher/msm-fb-refresher_git.bb
+++ b/recipes-core/msm-fb-refresher/msm-fb-refresher_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Some qualcomm devices need a refresher ioctl to show something on screen. This is a simple soft that does that on boot."
 PR = "r0"
-SRC_URI = "git://github.com/AsteroidOS/msm-fb-refresher.git;protocol=https \
+SRC_URI = "git://github.com/AsteroidOS/msm-fb-refresher.git;protocol=https;branch=master \
     file://msm-fb-refresher.service"
 SRCREV = "b89cca860f9c37e71b3fbd5ae53c4e8d521e1de8"
 LICENSE = "GPLv3"

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -13,7 +13,7 @@ do_install:append() {
     sed -i "s@agetty --noclear @agetty --autologin ceres @" ${D}/lib/systemd/system/getty@.service
 }
 
-PACKAGECONFIG:append += "pam"
+PACKAGECONFIG:append = " pam"
 
 PACKAGECONFIG:remove = "rfkill"
 

--- a/recipes-devtools/cmake/extra-cmake-modules_git.bb
+++ b/recipes-devtools/cmake/extra-cmake-modules_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Extra modules and scripts for CMake"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING-CMAKE-SCRIPTS;md5=54c7042be62e169199200bc6477f04d1"
 
 SRC_URI = "git://invent.kde.org/frameworks/extra-cmake-modules.git;protocol=https;branch=master"

--- a/recipes-devtools/gcc8/gcc8-8.3.inc
+++ b/recipes-devtools/gcc8/gcc8-8.3.inc
@@ -26,7 +26,7 @@ LIC_FILES_CHKSUM = "\
 #RELEASE = "8.0.1-RC-20180427"
 BASEURI ?= "${GNU_MIRROR}/gcc/gcc-${PV}/gcc-${PV}.tar.xz"
 #SRCREV = "f7cf798b73fd1a07098f9a490deec1e2a36e0bed"
-#BASEURI ?= "git://github.com/gcc-mirror/gcc;branch=gcc-6-branch;protocol=git"
+#BASEURI ?= "git://github.com/gcc-mirror/gcc;branch=gcc-6-branch;protocol=https"
 #BASEURI ?= "http://mirrors.concertpass.com/gcc/snapshots/${RELEASE}/gcc-${RELEASE}.tar.xz"
 
 SRC_URI = "\

--- a/recipes-devtools/gcc8/gcc8-8.3.inc
+++ b/recipes-devtools/gcc8/gcc8-8.3.inc
@@ -13,7 +13,7 @@ FILESEXTRAPATHS =. "${FILE_DIRNAME}/gcc8-8.3:"
 DEPENDS =+ "mpfr gmp libmpc zlib flex-native"
 NATIVEDEPS = "mpfr-native gmp-native libmpc-native zlib-native flex-native"
 
-LICENSE = "GPL-3.0-with-GCC-exception & GPLv3"
+LICENSE = "GPL-3.0-with-GCC-exception & GPL-3.0-only"
 
 LIC_FILES_CHKSUM = "\
     file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552 \

--- a/recipes-devtools/gcc8/gcc8-target.inc
+++ b/recipes-devtools/gcc8/gcc8-target.inc
@@ -239,4 +239,4 @@ do_install:append () {
 # and builds track file dependencies (e.g. perl and its makedepends code).
 # For determinism we don't install this ever and rely on the copy from gcc8-cross.
 # [YOCTO #7287]
-SYSROOT_DIRS_BLACKLIST += "${libdir}/gcc"
+SYSROOT_DIRS_IGNORE += "${libdir}/gcc"

--- a/recipes-graphics/ttf-fonts/ttf-asteroid-fonts_git.bb
+++ b/recipes-graphics/ttf-fonts/ttf-asteroid-fonts_git.bb
@@ -9,7 +9,7 @@ INHIBIT_DEFAULT_DEPS = "1"
 inherit allarch
 inherit fontcache
 
-SRC_URI = "git://github.com/AsteroidOS/asteroid-fonts.git;protocol=https \
+SRC_URI = "git://github.com/AsteroidOS/asteroid-fonts.git;protocol=https;branch=master \
     file://69-emoji.conf"
 SRCREV = "${AUTOREV}"
 PR = "r1"

--- a/recipes-multimedia/gstreamer/gst-droid_git.bb
+++ b/recipes-multimedia/gstreamer/gst-droid_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 inherit meson pkgconfig
 
-SRC_URI = "git://github.com/sailfishos/gst-droid.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/gst-droid.git;protocol=https;branch=master \
            file://0001-Remove-references-to-mode-that-are-not-in-upstream-g.patch"
 SRCREV = "cf2d5f9652364af471cac7d7f04388a7bab9448a"
 PR = "r1"

--- a/recipes-multimedia/gstreamer/gst-droid_git.bb
+++ b/recipes-multimedia/gstreamer/gst-droid_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Droid plugin for GStreamer"
 HOMEPAGE = "https://github.com/sailfishos/gst-droid"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 inherit meson pkgconfig

--- a/recipes-multimedia/gstreamer/nemo-gst-interfaces_git.bb
+++ b/recipes-multimedia/gstreamer/nemo-gst-interfaces_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemo mobile specific GStreamer interfaces"
 HOMEPAGE = "https://github.com/sailfishos/nemo-gst-interfaces/tree/master"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/sailfishos/nemo-gst-interfaces.git;protocol=https;branch=master"

--- a/recipes-multimedia/gstreamer/nemo-gst-interfaces_git.bb
+++ b/recipes-multimedia/gstreamer/nemo-gst-interfaces_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-gst-interfaces/tree/master"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/sailfishos/nemo-gst-interfaces.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/nemo-gst-interfaces.git;protocol=https;branch=master"
 SRCREV = "c1deaea7b52bbd12cea56c4ada69eba17cb602a8"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-multimedia/pulseaudio/pulseaudio-module-keepalive_git.bb
+++ b/recipes-multimedia/pulseaudio/pulseaudio-module-keepalive_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/pulseaudio-module-keepalive"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=f294906e6e4eac9d917503a0bbd139b4"
 
-SRC_URI = "git://github.com/sailfishos/pulseaudio-module-keepalive.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/pulseaudio-module-keepalive.git;protocol=https;branch=master \
     file://0001-Set-version-to-support-PulseAudio-15.patch"
 SRCREV = "3102ee5d92e7b8fb5adb6ea01aa8a47a9c7ce886"
 PR = "r1"

--- a/recipes-multimedia/pulseaudio/pulseaudio-module-keepalive_git.bb
+++ b/recipes-multimedia/pulseaudio/pulseaudio-module-keepalive_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemo keepalive plugin for PulseAudio"
 HOMEPAGE = "https://github.com/sailfishos/pulseaudio-module-keepalive"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=f294906e6e4eac9d917503a0bbd139b4"
 
 SRC_URI = "git://github.com/sailfishos/pulseaudio-module-keepalive.git;protocol=https;branch=master \

--- a/recipes-multimedia/pulseaudio/pulseaudio-modules-droid_git.bb
+++ b/recipes-multimedia/pulseaudio/pulseaudio-modules-droid_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/mer-hybris/pulseaudio-modules-droid"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=f294906e6e4eac9d917503a0bbd139b4"
 
-SRC_URI = "git://github.com/mer-hybris/pulseaudio-modules-droid;protocol=https \
+SRC_URI = "git://github.com/mer-hybris/pulseaudio-modules-droid;protocol=https;branch=master \
         file://0001-Set-version-to-support-PulseAudio-15.patch"
 SRCREV = "8283bbe5c932d34f6d427ce02abf455c23b3c3b1"
 PR = "r1"

--- a/recipes-multimedia/pulseaudio/pulseaudio-modules-droid_git.bb
+++ b/recipes-multimedia/pulseaudio/pulseaudio-modules-droid_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Android/hybris plugin for PulseAudio"
 HOMEPAGE = "https://github.com/mer-hybris/pulseaudio-modules-droid"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=f294906e6e4eac9d917503a0bbd139b4"
 
 SRC_URI = "git://github.com/mer-hybris/pulseaudio-modules-droid;protocol=https;branch=master \

--- a/recipes-multimedia/pulseaudio/pulseaudio-modules-nemo_git.bb
+++ b/recipes-multimedia/pulseaudio/pulseaudio-modules-nemo_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/pulseaudio-modules-nemo"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
-SRC_URI = "git://github.com/sailfishos/pulseaudio-modules-nemo.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/pulseaudio-modules-nemo.git;protocol=https;branch=master \
            file://0001-configure.ac-Check-hardfp-from-cross-compilation-too.patch \
            file://0002-Set-version-to-support-PulseAudio-15.patch"
 SRCREV = "d0dfdc3f895680f0c8839809f13f950090a77369"

--- a/recipes-multimedia/pulseaudio/pulseaudio-modules-nemo_git.bb
+++ b/recipes-multimedia/pulseaudio/pulseaudio-modules-nemo_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemo plugin for PulseAudio"
 HOMEPAGE = "https://github.com/sailfishos/pulseaudio-modules-nemo"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
 SRC_URI = "git://github.com/sailfishos/pulseaudio-modules-nemo.git;protocol=https;branch=master \

--- a/recipes-navigation/geoclue/geoclue_0.12.99.bb
+++ b/recipes-navigation/geoclue/geoclue_0.12.99.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "Geoclue is a D-Bus service that provides location information. \
 The primary goal of the Geoclue project is to make creating location-aware applications \
 as simple as possible, while the secondary goal is to ensure that no application \
 can access location information without explicit permission from user."
-LICENSE = "LGPLv2.0"
+LICENSE = "LGPL-2.0-only"
 SECTION = "console/network"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=149a9c1e8e40b7453ce8c62ed489f481"

--- a/recipes-nemomobile/buteo/buteo-mtp_git.bb
+++ b/recipes-nemomobile/buteo/buteo-mtp_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/buteo-mtp"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://mts/mts.cpp;beginline=1;endline=30;md5=a2b2b5351d5e7a0b1f3b62af44e24404"
 
-SRC_URI = "git://github.com/sailfishos/buteo-mtp.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/buteo-mtp.git;protocol=https;branch=master \
            file://0001-Remove-dependency-to-SSU-and-tests.patch \
            file://0002-fsstorageplugin-Expose-Watch-Memory-instead-of-Phone.patch \
            file://buteo-mtp"

--- a/recipes-nemomobile/buteo/buteo-mtp_git.bb
+++ b/recipes-nemomobile/buteo/buteo-mtp_git.bb
@@ -11,7 +11,7 @@ SRCREV = "6e0c7d9bb04926b69bb454b479a153ba84d28b9c"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 EXTRA_QMAKEVARS_PRE += "QMAKE_CFLAGS_ISYSTEM="
 

--- a/recipes-nemomobile/buteo/buteo-mtp_git.bb
+++ b/recipes-nemomobile/buteo/buteo-mtp_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "NemoMobile's MTP Stack"
 HOMEPAGE = "https://github.com/sailfishos/buteo-mtp"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://mts/mts.cpp;beginline=1;endline=30;md5=a2b2b5351d5e7a0b1f3b62af44e24404"
 
 SRC_URI = "git://github.com/sailfishos/buteo-mtp.git;protocol=https;branch=master \

--- a/recipes-nemomobile/buteo/buteo-syncfw_git.bb
+++ b/recipes-nemomobile/buteo/buteo-syncfw_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "NemoMobile's Buteo Synchronization daemon"
 HOMEPAGE = "https://github.com/sailfishos/buteo-syncfw"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=93ae0a8ec7ecf7709c725bd232bbafc6"
 
 SRC_URI = "git://github.com/sailfishos/buteo-syncfw.git;protocol=https;branch=master \

--- a/recipes-nemomobile/buteo/buteo-syncfw_git.bb
+++ b/recipes-nemomobile/buteo/buteo-syncfw_git.bb
@@ -9,7 +9,7 @@ SRCREV = "dc1483848049ad028cfdbdf563a9a6ce31032c59"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5 gsettings
+inherit qmake5 gsettings pkgconfig
 
 EXTRA_QMAKEVARS_PRE += "CONFIG+=usb-moded DEFINES+=USE_KEEPALIVE"
 

--- a/recipes-nemomobile/buteo/buteo-syncfw_git.bb
+++ b/recipes-nemomobile/buteo/buteo-syncfw_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/buteo-syncfw"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=93ae0a8ec7ecf7709c725bd232bbafc6"
 
-SRC_URI = "git://github.com/sailfishos/buteo-syncfw.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/buteo-syncfw.git;protocol=https;branch=master \
            file://msyncd.service"
 SRCREV = "dc1483848049ad028cfdbdf563a9a6ce31032c59"
 PR = "r1"

--- a/recipes-nemomobile/dsme/dsme_git.bb
+++ b/recipes-nemomobile/dsme/dsme_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/dsme"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
-SRC_URI = "gitsm://github.com/sailfishos/dsme.git;protocol=https \
+SRC_URI = "gitsm://github.com/sailfishos/dsme.git;protocol=https;branch=master \
     file://dsme.service"
 SRCREV = "d1518176a68ce416fd19515c0b88da2b48ce606a"
 PR = "r1"

--- a/recipes-nemomobile/dsme/dsme_git.bb
+++ b/recipes-nemomobile/dsme/dsme_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's DSME"
 HOMEPAGE = "https://github.com/sailfishos/dsme"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
 SRC_URI = "gitsm://github.com/sailfishos/dsme.git;protocol=https;branch=master \

--- a/recipes-nemomobile/dsme/libdsme_git.bb
+++ b/recipes-nemomobile/dsme/libdsme_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's libdsme."
 HOMEPAGE = "https://github.com/sailfishos/libdsme"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
 DEPENDS += " glib-2.0 libcheck pkgconfig-native"

--- a/recipes-nemomobile/dsme/libdsme_git.bb
+++ b/recipes-nemomobile/dsme/libdsme_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
 DEPENDS += " glib-2.0 libcheck pkgconfig-native"
 
-SRC_URI = "git://github.com/sailfishos/libdsme.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/libdsme.git;protocol=https;branch=master \
     file://001-Allows-custom-cflags.patch"
 SRCREV = "3633f59d801e576007a936ba88251a47d1b877f2"
 PR = "r1"

--- a/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris_git.bb
+++ b/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Libhybris backend for GeoClue"
 HOMEPAGE = "https://github.com/mer-hybris/geoclue-providers-hybris"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/mer-hybris/geoclue-providers-hybris.git;protocol=https;branch=master"

--- a/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris_git.bb
+++ b/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/mer-hybris/geoclue-providers-hybris"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/mer-hybris/geoclue-providers-hybris.git;protocol=https"
+SRC_URI = "git://github.com/mer-hybris/geoclue-providers-hybris.git;protocol=https;branch=master"
 SRCREV = "8775abcf9983abb4b8be28ad43f7a193edac5605"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/kf5bluezqt/kf5bluezqt_git.bb
+++ b/recipes-nemomobile/kf5bluezqt/kf5bluezqt_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Qt wrapper for BlueZ 5 DBus API, with partial support for BlueZ 4 backends"
 HOMEPAGE = "https://github.com/sailfishos/kf5bluezqt"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://bluez-qt/COPYING.LIB;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/sailfishos/kf5bluezqt.git;protocol=https;branch=master"

--- a/recipes-nemomobile/kf5bluezqt/kf5bluezqt_git.bb
+++ b/recipes-nemomobile/kf5bluezqt/kf5bluezqt_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/kf5bluezqt"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://bluez-qt/COPYING.LIB;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/sailfishos/kf5bluezqt.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/kf5bluezqt.git;protocol=https;branch=master"
 SRCREV = "65c7154e93bf302639e30c5a8ab6a2a4d6e36e40"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/libaccounts/libaccounts-glib_git.bb
+++ b/recipes-nemomobile/libaccounts/libaccounts-glib_git.bb
@@ -20,7 +20,7 @@ do_install:append() {
     rm -r ${D}/usr/lib/girepository-1.0/
 }
 
-DEPENDS += "glib-2.0 glib-2.0-native vala-native python3-pygobject-native gobject-introspection prelink-native qemu-native"
+DEPENDS += "glib-2.0 glib-2.0-native vala-native python3-pygobject-native gobject-introspection qemu-native"
 
 DEPENDS += "libcheck libxml2 sqlite3"
 

--- a/recipes-nemomobile/libaccounts/libaccounts-glib_git.bb
+++ b/recipes-nemomobile/libaccounts/libaccounts-glib_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "GLib-based client library for the accounts database"
 HOMEPAGE = "https://gitlab.com/accounts-sso/libaccounts-glib"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=243b725d71bb5df4a1e5920b344b86ad"
 
 inherit meson pkgconfig vala

--- a/recipes-nemomobile/libaccounts/libaccounts-glib_git.bb
+++ b/recipes-nemomobile/libaccounts/libaccounts-glib_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=243b725d71bb5df4a1e5920b344b86ad"
 
 inherit meson pkgconfig vala
 
-SRC_URI = "git://gitlab.com/accounts-sso/libaccounts-glib.git;protocol=https \
+SRC_URI = "git://gitlab.com/accounts-sso/libaccounts-glib.git;protocol=https;branch=master \
         file://0001-meson-Disable-docs-and-tests.patch"
 
 SRCREV = "886a80b3ba975d8a59a6500ade2b1debb552660c"

--- a/recipes-nemomobile/libaccounts/libaccounts-qt5_git.bb
+++ b/recipes-nemomobile/libaccounts/libaccounts-qt5_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Accounts management library for Qt applications"
 HOMEPAGE = "https://gitlab.com/accounts-sso/libaccounts-qt"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=243b725d71bb5df4a1e5920b344b86ad"
 
 SRC_URI = "git://gitlab.com/accounts-sso/libaccounts-qt.git;protocol=https;branch=master"

--- a/recipes-nemomobile/libaccounts/libaccounts-qt5_git.bb
+++ b/recipes-nemomobile/libaccounts/libaccounts-qt5_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://gitlab.com/accounts-sso/libaccounts-qt"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=243b725d71bb5df4a1e5920b344b86ad"
 
-SRC_URI = "git://gitlab.com/accounts-sso/libaccounts-qt.git;protocol=https"
+SRC_URI = "git://gitlab.com/accounts-sso/libaccounts-qt.git;protocol=https;branch=master"
 SRCREV = "f4d8af8dffb461a0eff9f03925fe6dbab9f1c1d2"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/libaccounts/libaccounts-qt5_git.bb
+++ b/recipes-nemomobile/libaccounts/libaccounts-qt5_git.bb
@@ -8,7 +8,7 @@ SRCREV = "f4d8af8dffb461a0eff9f03925fe6dbab9f1c1d2"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 do_configure:prepend() {
     sed -i "/doc.pri/d" ${S}/accounts-qt.pro
@@ -18,6 +18,6 @@ do_install:append() {
     rm -r ${D}/usr/bin/
 }
 
-DEPENDS += "qtbase libaccounts-glib "
+DEPENDS += "qtbase libaccounts-glib glib-2.0"
 
 FILES:${PN}-dev += "/usr/lib/cmake/AccountsQt5"

--- a/recipes-nemomobile/libiodata/libiodata_git.bb
+++ b/recipes-nemomobile/libiodata/libiodata_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/libiodata"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/sailfishos/libiodata.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/libiodata.git;protocol=https;branch=master"
 SRCREV = "7c2c0274c397a19fa9d855cd0116c37ae459ec54"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/libiodata/libiodata_git.bb
+++ b/recipes-nemomobile/libiodata/libiodata_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's libiodata"
 HOMEPAGE = "https://github.com/sailfishos/libiodata"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/sailfishos/libiodata.git;protocol=https;branch=master"

--- a/recipes-nemomobile/libiphb/libiphb_git.bb
+++ b/recipes-nemomobile/libiphb/libiphb_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's libiphb."
 HOMEPAGE = "https://github.com/sailfishos/libiphb"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/sailfishos/libiphb.git;protocol=https;branch=master"

--- a/recipes-nemomobile/libiphb/libiphb_git.bb
+++ b/recipes-nemomobile/libiphb/libiphb_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/libiphb"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/sailfishos/libiphb.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/libiphb.git;protocol=https;branch=master"
 
 SRCREV = "5db3ab70268933369fbfc90e8ca3fd00b774c66b"
 PR = "r1"

--- a/recipes-nemomobile/libmlocale/libmlocale_git.bb
+++ b/recipes-nemomobile/libmlocale/libmlocale_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Meego Locale library"
 HOMEPAGE = "https://github.com/sailfishos/libmlocale"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE.LGPL;md5=7635eef25dff78f483059bf21a20686d"
 
 SRC_URI = "git://github.com/sailfishos/libmlocale.git;protocol=https;branch=master \

--- a/recipes-nemomobile/libmlocale/libmlocale_git.bb
+++ b/recipes-nemomobile/libmlocale/libmlocale_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/libmlocale"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://LICENSE.LGPL;md5=7635eef25dff78f483059bf21a20686d"
 
-SRC_URI = "git://github.com/sailfishos/libmlocale.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/libmlocale.git;protocol=https;branch=master \
            file://0001-Allow-for-deprecated-functions.patch \
            file://0002-Disable-tests-and-doc.patch \
            file://0003-configure-Use-a-usr-prefix-by-default.patch"

--- a/recipes-nemomobile/libngf/libngf-qt_git.bb
+++ b/recipes-nemomobile/libngf/libngf-qt_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/libngf-qt"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/sailfishos/libngf-qt.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/libngf-qt.git;protocol=https;branch=master \
         file://0001-Disable-tests.patch"
 SRCREV = "8fabfc5b13ce2e5d4d914e47303844a5c42b388b"
 PR = "r1"

--- a/recipes-nemomobile/libngf/libngf-qt_git.bb
+++ b/recipes-nemomobile/libngf/libngf-qt_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's libngf-qt"
 HOMEPAGE = "https://github.com/sailfishos/libngf-qt"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/sailfishos/libngf-qt.git;protocol=https;branch=master \

--- a/recipes-nemomobile/libngf/libngf_git.bb
+++ b/recipes-nemomobile/libngf/libngf_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's libngf"
 HOMEPAGE = "https://github.com/sailfishos/libngf"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/sailfishos/libngf.git;protocol=https;branch=master \

--- a/recipes-nemomobile/libngf/libngf_git.bb
+++ b/recipes-nemomobile/libngf/libngf_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/libngf"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/sailfishos/libngf.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/libngf.git;protocol=https;branch=master \
         file://0001-Disable-tests.patch"
 SRCREV = "06be88da245bf5eed6880e871f65d35115d05674"
 PR = "r1"

--- a/recipes-nemomobile/libqtsparql/libqtsparql_git.bb
+++ b/recipes-nemomobile/libqtsparql/libqtsparql_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Mer's libqtsparql"
 HOMEPAGE = "https://github.com/sailfishos/libqtsparql"
-LICENSE = "LGPL-2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://LICENSE.LGPL;md5=f922d7c79b72c75fe134d22f3c868337"
 
 SRC_URI = "git://github.com/sailfishos/libqtsparql.git;protocol=https;branch=master"

--- a/recipes-nemomobile/libqtsparql/libqtsparql_git.bb
+++ b/recipes-nemomobile/libqtsparql/libqtsparql_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/libqtsparql"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://LICENSE.LGPL;md5=f922d7c79b72c75fe134d22f3c868337"
 
-SRC_URI = "git://github.com/sailfishos/libqtsparql.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/libqtsparql.git;protocol=https;branch=master"
 SRCREV = "2332b2d471ffb5d7884fc45c0031c9d60127ea84"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/libresource/libresource_git.bb
+++ b/recipes-nemomobile/libresource/libresource_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/libresource"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/sailfishos/libresource.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/libresource.git;protocol=https;branch=master"
 SRCREV = "0af1cea2bf457a911baa7cd65ee1e32747df3011"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/libresource/libresource_git.bb
+++ b/recipes-nemomobile/libresource/libresource_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's libresource"
 HOMEPAGE = "https://github.com/sailfishos/libresource"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/sailfishos/libresource.git;protocol=https;branch=master"

--- a/recipes-nemomobile/libresource/libresourceqt_git.bb
+++ b/recipes-nemomobile/libresource/libresourceqt_git.bb
@@ -11,7 +11,7 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 DEPENDS += " qtbase libresource dbus virtual/libgles2"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 B = "${WORKDIR}/git"
 

--- a/recipes-nemomobile/libresource/libresourceqt_git.bb
+++ b/recipes-nemomobile/libresource/libresourceqt_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's libresourceqt"
 HOMEPAGE = "https://github.com/mer-packages/libresourceqt"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/mer-packages/libresourceqt;protocol=https;branch=master \

--- a/recipes-nemomobile/libresource/libresourceqt_git.bb
+++ b/recipes-nemomobile/libresource/libresourceqt_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/mer-packages/libresourceqt"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/mer-packages/libresourceqt;protocol=https \
+SRC_URI = "git://github.com/mer-packages/libresourceqt;protocol=https;branch=master \
     file://001-Disables_resourceqt-client_build.patch"
 SRCREV = "4483fd800ab67c66d33ff30b28bd5c3137feec7a"
 PR = "r1"

--- a/recipes-nemomobile/libsailfishkeyprovider/libsailfishkeyprovider_git.bb
+++ b/recipes-nemomobile/libsailfishkeyprovider/libsailfishkeyprovider_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/libsailfishkeyprovider"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://../license.lgpl;md5=cf3f442f331daf906e35a3e770768003"
 
-SRC_URI = "git://github.com/sailfishos/libsailfishkeyprovider.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/libsailfishkeyprovider.git;protocol=https;branch=master"
 SRCREV = "ebe72a1d6e631bbb9cb3814ed2599d5910930008"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/libsailfishkeyprovider/libsailfishkeyprovider_git.bb
+++ b/recipes-nemomobile/libsailfishkeyprovider/libsailfishkeyprovider_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Qt wrapper for BlueZ 5 DBus API, with partial support for BlueZ 4 backends"
 HOMEPAGE = "https://github.com/sailfishos/libsailfishkeyprovider"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://../license.lgpl;md5=cf3f442f331daf906e35a3e770768003"
 
 SRC_URI = "git://github.com/sailfishos/libsailfishkeyprovider.git;protocol=https;branch=master"

--- a/recipes-nemomobile/libshadowutils/libshadowutils_git.bb
+++ b/recipes-nemomobile/libshadowutils/libshadowutils_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's libshadowutils"
 HOMEPAGE = "https://github.com/sailfishos/libshadowutils"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=08c553a87d4e51bbed50b20e0adcaede"
 
 SRC_URI = "git://github.com/sailfishos/libshadowutils.git;protocol=https;branch=master"

--- a/recipes-nemomobile/libshadowutils/libshadowutils_git.bb
+++ b/recipes-nemomobile/libshadowutils/libshadowutils_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/libshadowutils"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=08c553a87d4e51bbed50b20e0adcaede"
 
-SRC_URI = "git://github.com/sailfishos/libshadowutils.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/libshadowutils.git;protocol=https;branch=master"
 SRCREV = "c26249a780a81281a0ecdf44ffa8b37a13185966"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/libsignon-qt5/libsignon-qt5_git.bb
+++ b/recipes-nemomobile/libsignon-qt5/libsignon-qt5_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://gitlab.com/accounts-sso/signond"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=243b725d71bb5df4a1e5920b344b86ad"
 
-SRC_URI = "git://gitlab.com/accounts-sso/signond.git;protocol=https"
+SRC_URI = "git://gitlab.com/accounts-sso/signond.git;protocol=https;branch=master"
 SRCREV = "4212b454da1cab2ef36f8def1b3d75cab0506a71"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/libsignon-qt5/libsignon-qt5_git.bb
+++ b/recipes-nemomobile/libsignon-qt5/libsignon-qt5_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Single Sign On framework"
 HOMEPAGE = "https://gitlab.com/accounts-sso/signond"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=243b725d71bb5df4a1e5920b344b86ad"
 
 SRC_URI = "git://gitlab.com/accounts-sso/signond.git;protocol=https;branch=master"

--- a/recipes-nemomobile/lipstick/lipstick_git.bb
+++ b/recipes-nemomobile/lipstick/lipstick_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Lipstick is a project aimed at offering easy to modify user experiences for varying mobile device form factors, e.g. handsets, netbooks, tablets."
 HOMEPAGE = "https://github.com/sailfishos/lipstick"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE.LGPL;md5=fbc093901857fcd118f065f900982c24"
 
 SRC_URI = "git://github.com/AsteroidOS/lipstick.git;protocol=https;branch=master \

--- a/recipes-nemomobile/lipstick/lipstick_git.bb
+++ b/recipes-nemomobile/lipstick/lipstick_git.bb
@@ -20,7 +20,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 DEPENDS += "timed qtbase qtsensors qtdeclarative qtwayland mlite dbus dbus-glib libresourceqt qtsystems libngf-qt mce usb-moded-qt5 systemd wayland nemo-keepalive qttools-native mce-qt5"
 RDEPENDS:${PN} += "${PN}-locale"
 
-inherit qmake5
+inherit qmake5 pkgconfig
 
 do_install:append() {
     install -d ${D}/usr/share/icons/hicolor/86x86/apps/

--- a/recipes-nemomobile/lipstick/lipstick_git.bb
+++ b/recipes-nemomobile/lipstick/lipstick_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/lipstick"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://LICENSE.LGPL;md5=fbc093901857fcd118f065f900982c24"
 
-SRC_URI = "git://github.com/AsteroidOS/lipstick.git;protocol=https \
+SRC_URI = "git://github.com/AsteroidOS/lipstick.git;protocol=https;branch=master \
     file://0001-Disables-tests-and-doc.patch \
     file://0002-notificationcategories-use-ion-icons.patch \
     file://0003-Disable-USB-mode-notifications-on-connect.patch \

--- a/recipes-nemomobile/mapplauncherd/mapplauncherd-booster-qtcomponents_git.bb
+++ b/recipes-nemomobile/mapplauncherd/mapplauncherd-booster-qtcomponents_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QtComponents plugin for mapplauncherd"
 HOMEPAGE = "https://github.com/sailfishos/mapplauncherd-booster-qtcomponents"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://src/qmlbooster.cpp;beginline=1;endline=18;md5=7e2bc276f949feb1d8229e665a6a2559"
 
 SRC_URI = "git://github.com/sailfishos/mapplauncherd-booster-qtcomponents.git;protocol=https;branch=master \

--- a/recipes-nemomobile/mapplauncherd/mapplauncherd-booster-qtcomponents_git.bb
+++ b/recipes-nemomobile/mapplauncherd/mapplauncherd-booster-qtcomponents_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/mapplauncherd-booster-qtcomponents"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://src/qmlbooster.cpp;beginline=1;endline=18;md5=7e2bc276f949feb1d8229e665a6a2559"
 
-SRC_URI = "git://github.com/sailfishos/mapplauncherd-booster-qtcomponents.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/mapplauncherd-booster-qtcomponents.git;protocol=https;branch=master \
           file://booster-qtcomponents-qt5.service \
           file://preload.qml"
 SRCREV = "0905e88e4091df667baa2155b7cf1683552b1e79"

--- a/recipes-nemomobile/mapplauncherd/mapplauncherd-qt/0001-mdeclarativecache5-Share-same-mdeclarativecache_pre_.patch
+++ b/recipes-nemomobile/mapplauncherd/mapplauncherd-qt/0001-mdeclarativecache5-Share-same-mdeclarativecache_pre_.patch
@@ -1,7 +1,8 @@
-From d106c0397438c14cc450c20f8a7adbe83bb13a86 Mon Sep 17 00:00:00 2001
+From 9e0172cb6382c93e3bea5aed48145ae2f85e8551 Mon Sep 17 00:00:00 2001
 From: Florent Revest <revestflo@gmail.com>
 Date: Mon, 12 Jun 2017 02:02:45 +0200
 Subject: [PATCH] mdeclarativecache5: Share same
+
  mdeclarativecache_pre_initialized_qapplication for each qmlcache
 
 ---
@@ -9,12 +10,12 @@ Subject: [PATCH] mdeclarativecache5: Share same
  1 file changed, 1 insertion(+), 7 deletions(-)
 
 diff --git a/mdeclarativecache5/mdeclarativecache.cpp b/mdeclarativecache5/mdeclarativecache.cpp
-index 622eac9..73ccdc8 100644
+index 4b9e4af..588f164 100644
 --- a/mdeclarativecache5/mdeclarativecache.cpp
 +++ b/mdeclarativecache5/mdeclarativecache.cpp
 @@ -61,13 +61,7 @@ void MDeclarativeCachePrivate::populate()
      cachePopulated = true;
-
+     
      static const char *const emptyString = "";
 -    static const QString appNameFormat = "mdeclarativecache_pre_initialized_qapplication-%1";
 -    static QByteArray appName;
@@ -24,8 +25,6 @@ index 622eac9..73ccdc8 100644
 -    // a dbus service with the application's name.
 -    appName = appNameFormat.arg(getpid()).toLatin1();
 +    static QByteArray appName = "mdeclarativecache_pre_initialized_qapplication";
-
+ 
      // We support at most ARGV_LIMIT arguments in QCoreApplication. These will be set when real
-     // arguments are known (in MDeclarativeCachePrivate::qApplication).
---
-2.7.4
+     // arguments are known (in MDeclarativeCachePrivate::qApplication). 

--- a/recipes-nemomobile/mapplauncherd/mapplauncherd-qt/0002-qdeclarative5-boostable-Compile-apps-as-shared-libra.patch
+++ b/recipes-nemomobile/mapplauncherd/mapplauncherd-qt/0002-qdeclarative5-boostable-Compile-apps-as-shared-libra.patch
@@ -1,4 +1,4 @@
-From 2512e5629672781bc94a92d91e3ab4f1ce8ce6c5 Mon Sep 17 00:00:00 2001
+From 628c0ce3070b0e9f25318caf844614bea915c25c Mon Sep 17 00:00:00 2001
 From: MagneFire <IDaNLContact@gmail.com>
 Date: Sat, 9 Jan 2021 15:04:25 +0100
 Subject: [PATCH] qdeclarative5-boostable: Compile apps as shared libraries. As
@@ -20,6 +20,4 @@ index 20b97f8..0e1191e 100644
 -Libs: -pie -rdynamic -lmdeclarativecache5
 +Libs: -shared -rdynamic -lmdeclarativecache5
  Cflags: -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -I/usr/include/mdeclarativecache5
-
---
-2.30.0
+ 

--- a/recipes-nemomobile/mapplauncherd/mapplauncherd-qt_git.bb
+++ b/recipes-nemomobile/mapplauncherd/mapplauncherd-qt_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/mapplauncherd-qt"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://qtbooster/qtbooster.cpp;beginline=1;endline=18;md5=fb70bd5bb640878875111d8161fa303c"
 
-SRC_URI = "git://github.com/sailfishos/mapplauncherd-qt.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/mapplauncherd-qt.git;protocol=https;branch=master \
            file://0001-mdeclarativecache5-Share-same-mdeclarativecache_pre_.patch \
            file://0002-qdeclarative5-boostable-Compile-apps-as-shared-libra.patch \
            file://booster-qt5.service"

--- a/recipes-nemomobile/mapplauncherd/mapplauncherd-qt_git.bb
+++ b/recipes-nemomobile/mapplauncherd/mapplauncherd-qt_git.bb
@@ -11,9 +11,9 @@ SRCREV = "1ff776d787e3c95424a9925097658ef99a6221ba"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
-DEPENDS += "qtdeclarative qtbase mapplauncherd"
+DEPENDS += "qtdeclarative qtbase mapplauncherd glib-2.0"
 RDEPENDS:${PN} += "mapplauncherd"
 
 do_configure:prepend() {

--- a/recipes-nemomobile/mapplauncherd/mapplauncherd-qt_git.bb
+++ b/recipes-nemomobile/mapplauncherd/mapplauncherd-qt_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Qt plugin for mapplauncherd"
 HOMEPAGE = "https://github.com/sailfishos/mapplauncherd-qt"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://qtbooster/qtbooster.cpp;beginline=1;endline=18;md5=fb70bd5bb640878875111d8161fa303c"
 
 SRC_URI = "git://github.com/sailfishos/mapplauncherd-qt.git;protocol=https;branch=master \

--- a/recipes-nemomobile/mapplauncherd/mapplauncherd_git.bb
+++ b/recipes-nemomobile/mapplauncherd/mapplauncherd_git.bb
@@ -13,9 +13,9 @@ PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-DEPENDS += "dbus systemd"
+DEPENDS += "dbus systemd glib-2.0"
 
-inherit cmake
+inherit cmake pkgconfig
 B = "${S}"
 
 do_configure:prepend() {

--- a/recipes-nemomobile/mapplauncherd/mapplauncherd_git.bb
+++ b/recipes-nemomobile/mapplauncherd/mapplauncherd_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/mapplauncherd"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING.LESSER;md5=243b725d71bb5df4a1e5920b344b86ad"
 
-SRC_URI = "git://github.com/sailfishos/mapplauncherd.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/mapplauncherd.git;protocol=https;branch=master \
            file://0001-booster-generic-Fix-path-to-tibapplauncherd.patch \
            file://0002-Fix-reference-to-host-lib.patch \
            file://0003-Fix-dynamic-opening-issues.patch \

--- a/recipes-nemomobile/mapplauncherd/mapplauncherd_git.bb
+++ b/recipes-nemomobile/mapplauncherd/mapplauncherd_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Daemon that helps to launch applications faster by preloading dynamically linked libraries and caching stuff"
 HOMEPAGE = "https://github.com/sailfishos/mapplauncherd"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING.LESSER;md5=243b725d71bb5df4a1e5920b344b86ad"
 
 SRC_URI = "git://github.com/sailfishos/mapplauncherd.git;protocol=https;branch=master \

--- a/recipes-nemomobile/mce/mce-plugin-libhybris_git.bb
+++ b/recipes-nemomobile/mce/mce-plugin-libhybris_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "libhybris plugin for the Nemomobile's MCE."
 HOMEPAGE = "https://github.com/nemomobile/mce-plugin-libhybris.git"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/nemomobile/mce-plugin-libhybris.git;protocol=https;branch=master"

--- a/recipes-nemomobile/mce/mce-plugin-libhybris_git.bb
+++ b/recipes-nemomobile/mce/mce-plugin-libhybris_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/nemomobile/mce-plugin-libhybris.git"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/nemomobile/mce-plugin-libhybris.git;protocol=https"
+SRC_URI = "git://github.com/nemomobile/mce-plugin-libhybris.git;protocol=https;branch=master"
 SRCREV = "b2f6330fdd4af9b11a6be64d93c976851f0ba567"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/mce/mce-qt5_git.bb
+++ b/recipes-nemomobile/mce/mce-qt5_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://git.merproject.org/mer-core/libmce-qt"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://lib/src/qmcebatterylevel.cpp;beginline=1;endline=36;md5=7a1b79e2ca9fb0d250c13ccfe76dd0fc"
 
-SRC_URI = "git://github.com/sailfishos/libmce-qt.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/libmce-qt.git;protocol=https;branch=master"
 SRCREV = "431168d7c91ab7c3cfc9d2283ab1a26f09422228"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/mce/mce-qt5_git.bb
+++ b/recipes-nemomobile/mce/mce-qt5_git.bb
@@ -10,6 +10,6 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 DEPENDS += "qtbase qtdeclarative mce"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 FILES:${PN} += "/usr/lib/qml/Nemo/Mce/"

--- a/recipes-nemomobile/mce/mce-qt5_git.bb
+++ b/recipes-nemomobile/mce/mce-qt5_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Mce Qt bindings."
-HOMEPAGE = "https://git.merproject.org/mer-core/libmce-qt"
-LICENSE = "BSD"
+HOMEPAGE = "https://github.com/sailfishos/libmce-qt"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://lib/src/qmcebatterylevel.cpp;beginline=1;endline=36;md5=7a1b79e2ca9fb0d250c13ccfe76dd0fc"
 
 SRC_URI = "git://github.com/sailfishos/libmce-qt.git;protocol=https;branch=master"

--- a/recipes-nemomobile/mce/mce_git.bb
+++ b/recipes-nemomobile/mce/mce_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's MCE."
 HOMEPAGE = "https://github.com/sailfishos/mce"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "gitsm://github.com/sailfishos/mce.git;protocol=https;branch=master \

--- a/recipes-nemomobile/mce/mce_git.bb
+++ b/recipes-nemomobile/mce/mce_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/mce"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "gitsm://github.com/sailfishos/mce.git;protocol=https \
+SRC_URI = "gitsm://github.com/sailfishos/mce.git;protocol=https;branch=master \
     file://0001-Double-tap-emulation-Adapts-the-state-machine-to-a-s.patch \
     file://0002-tilt-to-wake-Wake-screen-when-wrist-gesture-arrives.patch \
     file://0003-inactivity-Allow-activities-in-lockscreen-mode.-aste.patch \

--- a/recipes-nemomobile/mce/mcedevel_git.bb
+++ b/recipes-nemomobile/mce/mcedevel_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's MCE's development files."
 HOMEPAGE = "https://github.com/sailfishos/mce-dev"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
 SRC_URI = "git://github.com/sailfishos/mce-dev.git;protocol=https;branch=master"

--- a/recipes-nemomobile/mce/mcedevel_git.bb
+++ b/recipes-nemomobile/mce/mcedevel_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/mce-dev"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
-SRC_URI = "git://github.com/sailfishos/mce-dev.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/mce-dev.git;protocol=https;branch=master"
 SRCREV = "5af012a1ac579d90aa5d44ce1cee6cc4cfe2b040"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/mlite/mlite_git.bb
+++ b/recipes-nemomobile/mlite/mlite_git.bb
@@ -12,7 +12,7 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 DEPENDS:append = "qtbase glib-2.0 dconf"
-inherit qmake5
+inherit qmake5 pkgconfig
 B = "${WORKDIR}/git" 
 # Out of dir build breaks mlite5.pc installation
 

--- a/recipes-nemomobile/mlite/mlite_git.bb
+++ b/recipes-nemomobile/mlite/mlite_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "A light version of meegotouch, pulling in useful parts without requiring the full heavy library."
 HOMEPAGE = "https://github.com/sailfishos/mlite"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://src/mnotification.cpp;beginline=1;endline=18;md5=5dd5d73b0225b3099a82e6ad93283ea1"
 
 SRC_URI = "git://github.com/sailfishos/mlite.git;protocol=https;branch=master \

--- a/recipes-nemomobile/mlite/mlite_git.bb
+++ b/recipes-nemomobile/mlite/mlite_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/mlite"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://src/mnotification.cpp;beginline=1;endline=18;md5=5dd5d73b0225b3099a82e6ad93283ea1"
 
-SRC_URI = "git://github.com/sailfishos/mlite.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/mlite.git;protocol=https;branch=master \
            file://0001-MDesktopEntry-Allow-dynamic-locale-switch-by-disabli.patch \
            file://0002-mlite-Disable-tests.patch "
 SRCREV = "37ded5a0ca8f0770e3347f3711c7c4603d2a5b25"

--- a/recipes-nemomobile/nemo-keepalive/nemo-keepalive_git.bb
+++ b/recipes-nemomobile/nemo-keepalive/nemo-keepalive_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-keepalive"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://license.lgpl;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/sailfishos/nemo-keepalive.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/nemo-keepalive.git;protocol=https;branch=master \
         file://0001-Disable-tests.patch"
 SRCREV = "12a1528bacd20e0a07e9bbcbc287b08641986265"
 PR = "r1"

--- a/recipes-nemomobile/nemo-keepalive/nemo-keepalive_git.bb
+++ b/recipes-nemomobile/nemo-keepalive/nemo-keepalive_git.bb
@@ -9,7 +9,7 @@ SRCREV = "12a1528bacd20e0a07e9bbcbc287b08641986265"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 DEPENDS += "libiphb qtbase mce glib-2.0 qtdeclarative"
 

--- a/recipes-nemomobile/nemo-keepalive/nemo-keepalive_git.bb
+++ b/recipes-nemomobile/nemo-keepalive/nemo-keepalive_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Keeps the system from automatically blanking the display"
 HOMEPAGE = "https://github.com/sailfishos/nemo-keepalive"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://license.lgpl;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/sailfishos/nemo-keepalive.git;protocol=https;branch=master \

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-alarms_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-alarms_git.bb
@@ -9,7 +9,7 @@ SRCREV = "2893188822726fcaaf1d70f74f64bfecd07d3b13"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 DEPENDS += "qtdeclarative timed"
 

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-alarms_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-alarms_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-alarms"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/plugin.cpp;beginline=1;endline=31;md5=51d0e64178c105c6066f6731ee6f40b6"
 
-SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-alarms.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-alarms.git;protocol=https;branch=master \
         file://0001-Disable-tests.patch"
 SRCREV = "2893188822726fcaaf1d70f74f64bfecd07d3b13"
 PR = "r1"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-alarms_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-alarms_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML Plugin for alarms on Nemo"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-alarms"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/plugin.cpp;beginline=1;endline=31;md5=51d0e64178c105c6066f6731ee6f40b6"
 
 SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-alarms.git;protocol=https;branch=master \

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-calendar_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-calendar_git.bb
@@ -8,7 +8,7 @@ SRCREV = "dcf610f82840016b254896035d4223baa559075e"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 DEPENDS += "qtdeclarative kcalcore mkcal libaccounts-qt5"
 

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-calendar_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-calendar_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-calendar"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/plugin.cpp;beginline=1;endline=31;md5=4f66b392565d1dd726d4c892676d96fd"
 
-SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-calendar.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-calendar.git;protocol=https;branch=master"
 SRCREV = "dcf610f82840016b254896035d4223baa559075e"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-calendar_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-calendar_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML Plugin for calendar on Nemo"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-calendar"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/plugin.cpp;beginline=1;endline=31;md5=4f66b392565d1dd726d4c892676d96fd"
 
 SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-calendar.git;protocol=https;branch=master"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-configuration_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-configuration_git.bb
@@ -8,7 +8,7 @@ SRCREV = "d5aa1acefa102879bd4dfd2a7eee461a3f85df28"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 DEPENDS += "qtdeclarative mlite"
 

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-configuration_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-configuration_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML Plugin for configuration on Nemo"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-configuration"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/plugin.cpp;beginline=1;endline=30;md5=c9e59c313a1a503510332399ae73d430"
 
 SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-configuration.git;protocol=https;branch=master"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-configuration_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-configuration_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-configuration"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/plugin.cpp;beginline=1;endline=30;md5=c9e59c313a1a503510332399ae73d430"
 
-SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-configuration.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-configuration.git;protocol=https;branch=master"
 SRCREV = "d5aa1acefa102879bd4dfd2a7eee461a3f85df28"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-connectivity_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-connectivity_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML Plugin for connectivity on Nemo"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-connectivity/"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/plugin/plugin.cpp;beginline=1;endline=31;md5=a286bacf410e770064c78ac9470af1a2"
 
 SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-connectivity.git;protocol=https;branch=master"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-connectivity_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-connectivity_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-connectivity/"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/plugin/plugin.cpp;beginline=1;endline=31;md5=a286bacf410e770064c78ac9470af1a2"
 
-SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-connectivity.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-connectivity.git;protocol=https;branch=master"
 SRCREV = "f3707cbd1890fdce077db145c431e53e4160dc8b"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-connectivity_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-connectivity_git.bb
@@ -8,7 +8,7 @@ SRCREV = "f3707cbd1890fdce077db145c431e53e4160dc8b"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 DEPENDS += "qtdeclarative qtbase libconnman-qt5 qofonoext"
 

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-dbus_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-dbus_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML Plugin for DBus on Nemo"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-dbus"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/plugin/plugin.cpp;beginline=1;endline=21;md5=04fd4aa47861531d12b7453bc0ea24ee"
 
 SRC_URI = "gitsm://github.com/sailfishos/nemo-qml-plugin-dbus.git;protocol=https;branch=master"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-dbus_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-dbus_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-dbus"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/plugin/plugin.cpp;beginline=1;endline=21;md5=04fd4aa47861531d12b7453bc0ea24ee"
 
-SRC_URI = "gitsm://github.com/sailfishos/nemo-qml-plugin-dbus.git;protocol=https"
+SRC_URI = "gitsm://github.com/sailfishos/nemo-qml-plugin-dbus.git;protocol=https;branch=master"
 SRCREV = "d5a0ea1a3a5a221c9fe5b2eedaba79f984970738"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-devicelock_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-devicelock_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML Plugin for devicelock on Nemo"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-devicelock.git"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/plugin/plugin.cpp;beginline=1;endline=31;md5=7abcb4ac64856fce624f8f11084f659f"
 
 SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-devicelock.git;protocol=https;branch=master \

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-devicelock_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-devicelock_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-devicelock.git"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/plugin/plugin.cpp;beginline=1;endline=31;md5=7abcb4ac64856fce624f8f11084f659f"
 
-SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-devicelock.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-devicelock.git;protocol=https;branch=master \
            file://0001-Use-libsystemd-instead-of-libsystemd-daemon.patch"
 SRCREV = "acc349bee2deb3ea287df8deeeff2bff17203048"
 PR = "r1"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-models_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-models_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-models"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/plugin/plugin.cpp;beginline=1;endline=31;md5=95b47fdc8bb7e842db36790ec722350a"
 
-SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-models.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-models.git;protocol=https;branch=master"
 SRCREV = "242c95ba87fe5cecfe37de40c96a2cced124572d"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-models_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-models_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML Plugin for models on Nemo"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-models"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/plugin/plugin.cpp;beginline=1;endline=31;md5=95b47fdc8bb7e842db36790ec722350a"
 
 SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-models.git;protocol=https;branch=master"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-models_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-models_git.bb
@@ -8,7 +8,7 @@ SRCREV = "242c95ba87fe5cecfe37de40c96a2cced124572d"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 DEPENDS += "qtdeclarative timed libmlocale"
 

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-notifications_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-notifications_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML Plugin for notifications on Nemo"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-notifications"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/plugin/plugin.cpp;beginline=1;endline=31;md5=71911a081287caa33b542251575d913d"
 
 SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-notifications.git;protocol=https;branch=master"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-notifications_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-notifications_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-notifications"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/plugin/plugin.cpp;beginline=1;endline=31;md5=71911a081287caa33b542251575d913d"
 
-SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-notifications.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-notifications.git;protocol=https;branch=master"
 SRCREV = "84fa6a95eedb6f7d36523033ec7f45883d7c176f"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-policy_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-policy_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML Plugin for media policy on Nemo"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-policy"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/plugin.cpp;beginline=1;endline=31;md5=bcbb827372d72ea4e42de457e3575a9d"
 
 SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-policy.git;protocol=https;branch=master"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-policy_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-policy_git.bb
@@ -8,7 +8,7 @@ SRCREV = "bf95587eb980255f02205e04fdeafbb461cc929d"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 DEPENDS += "qtdeclarative qtbase libresourceqt"
 

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-policy_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-policy_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-policy"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/plugin.cpp;beginline=1;endline=31;md5=bcbb827372d72ea4e42de457e3575a9d"
 
-SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-policy.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-policy.git;protocol=https;branch=master"
 SRCREV = "bf95587eb980255f02205e04fdeafbb461cc929d"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-social_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-social_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML Plugin for social on Nemo"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-social/"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/plugin.cpp;beginline=1;endline=31;md5=f8c85a4530dff183f906f55efc59b98d"
 
 SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-social.git;protocol=https;branch=master"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-social_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-social_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-social/"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/plugin.cpp;beginline=1;endline=31;md5=f8c85a4530dff183f906f55efc59b98d"
 
-SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-social.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-social.git;protocol=https;branch=master"
 SRCREV = "1fb5b87badd487651ad4664207683d628e55919c"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-systemsettings_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-systemsettings_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML Plugin for system settings on Nemo"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-systemsettings"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/displaysettings.cpp;beginline=1;endline=31;md5=99ff23884718e3e2c85992a9294d18df"
 
 SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-systemsettings.git;protocol=https;branch=master \

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-systemsettings_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-systemsettings_git.bb
@@ -13,7 +13,7 @@ SRCREV = "8ee508e5370487afef1826e2ebaff0e44e604300"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 do_install:append() {
     cp ${WORKDIR}/location.conf ${D}/etc/location/

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-systemsettings_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-systemsettings_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-systemsettings"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/displaysettings.cpp;beginline=1;endline=31;md5=99ff23884718e3e2c85992a9294d18df"
 
-SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-systemsettings.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-systemsettings.git;protocol=https;branch=master \
     file://location.conf \
     file://0001-Disable-SSU-dependency.patch \
     file://0002-languagemodel-install-languages-in-usr-share-support.patch \

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-thumbnailer_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-thumbnailer_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-thumbnailer"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/plugin/plugin.cpp;beginline=1;endline=31;md5=99bfde884fbd54d5f6958982e31a4237"
 
-SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-thumbnailer.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-thumbnailer.git;protocol=https;branch=master"
 SRCREV = "7b0001877b734ddee733cd3042a3151657f478dc"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-thumbnailer_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-thumbnailer_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML Plugin for thumbnails generation on Nemo"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-thumbnailer"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/plugin/plugin.cpp;beginline=1;endline=31;md5=99bfde884fbd54d5f6958982e31a4237"
 
 SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-thumbnailer.git;protocol=https;branch=master"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-time_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-time_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QML Plugin for time on Nemo"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-time"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/plugin.cpp;beginline=1;endline=31;md5=6fe870673c7cd84b28372abaa5be2f48"
 
 SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-time.git;protocol=https;branch=master"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-time_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-time_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-time"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/plugin.cpp;beginline=1;endline=31;md5=6fe870673c7cd84b28372abaa5be2f48"
 
-SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-time.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-time.git;protocol=https;branch=master"
 SRCREV = "d27ce76d70c4e1467c7b929803a71c3a5ec3ee14"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/ngfd/ngfd-plugin-droid-vibrator_git.bb
+++ b/recipes-nemomobile/ngfd/ngfd-plugin-droid-vibrator_git.bb
@@ -4,7 +4,7 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 FILESEXTRAPATHS:append := "${THISDIR}/${PN}:"
-SRC_URI = "git://github.com/mer-hybris/ngfd-plugin-droid-vibrator.git;protocol=https \
+SRC_URI = "git://github.com/mer-hybris/ngfd-plugin-droid-vibrator.git;protocol=https;branch=master \
            file://50-droid-vibrator.ini"
 SRCREV = "ecb6b8e4b5314aaae784121c946525e1fc8cd9ac"
 PR = "r1"

--- a/recipes-nemomobile/ngfd/ngfd-plugin-droid-vibrator_git.bb
+++ b/recipes-nemomobile/ngfd/ngfd-plugin-droid-vibrator_git.bb
@@ -19,7 +19,7 @@ do_install:append () {
     cp ${WORKDIR}/50-droid-vibrator.ini ${D}/usr/share/ngfd/plugins.d/
 }
 
-inherit cmake
+inherit cmake pkgconfig
 
 FILES:${PN} += "/usr/lib/ngf/ /usr/share/ngfd/plugins.d/"
 FILES:${PN}-dbg += "/usr/lib/ngf/.debug/"

--- a/recipes-nemomobile/ngfd/ngfd-plugin-droid-vibrator_git.bb
+++ b/recipes-nemomobile/ngfd/ngfd-plugin-droid-vibrator_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's non graphical feedback daemon's hybris plugin"
 HOMEPAGE = "https://github.com/mer-hybris/ngfd-plugin-droid-vibrator"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 FILESEXTRAPATHS:append := "${THISDIR}/${PN}:"

--- a/recipes-nemomobile/ngfd/ngfd-plugin-pulse_git.bb
+++ b/recipes-nemomobile/ngfd/ngfd-plugin-pulse_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's non graphical feedback daemon's pulse plugin"
 HOMEPAGE = "https://github.com/sailfishos/ngfd-plugin-pulse"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/sailfishos/ngfd-plugin-pulse.git;protocol=https;branch=master"

--- a/recipes-nemomobile/ngfd/ngfd-plugin-pulse_git.bb
+++ b/recipes-nemomobile/ngfd/ngfd-plugin-pulse_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/ngfd-plugin-pulse"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/sailfishos/ngfd-plugin-pulse.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/ngfd-plugin-pulse.git;protocol=https;branch=master"
 SRCREV = "277c45626720ddcb3e3e89f2262fed9ac56fabfa"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/ngfd/ngfd_git.bb
+++ b/recipes-nemomobile/ngfd/ngfd_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/ngfd"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/sailfishos/ngfd.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/ngfd.git;protocol=https;branch=master \
            file://ngfd.ini \
            file://ngfd.service \
            file://events.d/ \

--- a/recipes-nemomobile/ngfd/ngfd_git.bb
+++ b/recipes-nemomobile/ngfd/ngfd_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's non graphical feedback daemon"
 HOMEPAGE = "https://github.com/sailfishos/ngfd"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/sailfishos/ngfd.git;protocol=https;branch=master \

--- a/recipes-nemomobile/profiled/libprofile-qt_git.bb
+++ b/recipes-nemomobile/profiled/libprofile-qt_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/libprofile-qt"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/profile.cpp;beginline=1;endline=34;md5=1bb00ceba8c2bf23723b34ecbfbad397"
 
-SRC_URI = "git://github.com/sailfishos/libprofile-qt.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/libprofile-qt.git;protocol=https;branch=master"
 SRCREV = "6aeb3a0b5ec9241b557dd0e838fbaa1f61d5215d"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/profiled/libprofile-qt_git.bb
+++ b/recipes-nemomobile/profiled/libprofile-qt_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Device profile handling library for Qt."
 HOMEPAGE = "https://github.com/sailfishos/libprofile-qt"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/profile.cpp;beginline=1;endline=34;md5=1bb00ceba8c2bf23723b34ecbfbad397"
 
 SRC_URI = "git://github.com/sailfishos/libprofile-qt.git;protocol=https;branch=master"

--- a/recipes-nemomobile/profiled/profiled_git.bb
+++ b/recipes-nemomobile/profiled/profiled_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/profiled"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://mainloop.c;beginline=1;endline=35;md5=5c3ca83e642104421900fdd3ecb1176e"
 
-SRC_URI = "git://github.com/sailfishos/profiled.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/profiled.git;protocol=https;branch=master \
     file://0001-Fixes-build.patch"
 SRCREV = "bf70ccf650330f1e2bc23b689e51015bb034b77d"
 PR = "r1"

--- a/recipes-nemomobile/profiled/profiled_git.bb
+++ b/recipes-nemomobile/profiled/profiled_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Daemon for device profile handling."
 HOMEPAGE = "https://github.com/sailfishos/profiled"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://mainloop.c;beginline=1;endline=35;md5=5c3ca83e642104421900fdd3ecb1176e"
 
 SRC_URI = "git://github.com/sailfishos/profiled.git;protocol=https;branch=master \

--- a/recipes-nemomobile/qofonoext/qofonoext_git.bb
+++ b/recipes-nemomobile/qofonoext/qofonoext_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "A library for accessing nemomobile specific ofono extensions, and a declarative plugin for it."
 HOMEPAGE = "https://github.com/sailfishos/libqofonoext"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://src/qofonoext.cpp;beginline=1;endline=14;md5=e78738e9230b2e0f55eb7f63e3444df5"
 
 SRC_URI = "git://github.com/sailfishos/libqofonoext.git;protocol=https;branch=master"

--- a/recipes-nemomobile/qofonoext/qofonoext_git.bb
+++ b/recipes-nemomobile/qofonoext/qofonoext_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/libqofonoext"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://src/qofonoext.cpp;beginline=1;endline=14;md5=e78738e9230b2e0f55eb7f63e3444df5"
 
-SRC_URI = "git://github.com/sailfishos/libqofonoext.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/libqofonoext.git;protocol=https;branch=master"
 SRCREV = "f19e882d4f7084acfa8681e57fa284218525a3d3"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/qofonoext/qofonoext_git.bb
+++ b/recipes-nemomobile/qofonoext/qofonoext_git.bb
@@ -10,6 +10,6 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 DEPENDS += "ofono qtbase libqofono qtsystems"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 FILES:${PN} += "/usr/lib/qml/org/nemomobile/ofono/"

--- a/recipes-nemomobile/qtdbusextended/qtdbusextended_git.bb
+++ b/recipes-nemomobile/qtdbusextended/qtdbusextended_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Extended DBus for Qt"
 HOMEPAGE = "https://github.com/nemomobile/qtdbusextended"
-LICENSE = "LGPL-2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=9851ce31b8dbc090eecd6cec46a8bf62"
 
 SRC_URI = "git://github.com/nemomobile/qtdbusextended.git;protocol=https;branch=master \

--- a/recipes-nemomobile/qtdbusextended/qtdbusextended_git.bb
+++ b/recipes-nemomobile/qtdbusextended/qtdbusextended_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/nemomobile/qtdbusextended"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=9851ce31b8dbc090eecd6cec46a8bf62"
 
-SRC_URI = "git://github.com/nemomobile/qtdbusextended.git;protocol=https \
+SRC_URI = "git://github.com/nemomobile/qtdbusextended.git;protocol=https;branch=master \
     file://0001-Use-variant-when-setting-properties.patch \
 "
 SRCREV = "34971431233dc408553245001148d34a09836df1"

--- a/recipes-nemomobile/qtmpris/qtmpris_git.bb
+++ b/recipes-nemomobile/qtmpris/qtmpris_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Qt and QML MPRIS interface and adaptor"
 HOMEPAGE = "https://github.com/nemomobile/qtmpris"
-LICENSE = "LGPL-2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5c936b15295e0f34fd6618c596808948"
 
 SRC_URI = "git://github.com/nemomobile/qtmpris.git;protocol=https;branch=master"

--- a/recipes-nemomobile/qtmpris/qtmpris_git.bb
+++ b/recipes-nemomobile/qtmpris/qtmpris_git.bb
@@ -8,7 +8,7 @@ SRCREV = "62c55e43dad6a479439ada609741ebebc4adaf23"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 DEPENDS += "qtdbusextended qtdeclarative"
 RDEPENDS:${PN} += "qtdbusextended"

--- a/recipes-nemomobile/qtmpris/qtmpris_git.bb
+++ b/recipes-nemomobile/qtmpris/qtmpris_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/nemomobile/qtmpris"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=5c936b15295e0f34fd6618c596808948"
 
-SRC_URI = "git://github.com/nemomobile/qtmpris.git;protocol=https"
+SRC_URI = "git://github.com/nemomobile/qtmpris.git;protocol=https;branch=master"
 SRCREV = "62c55e43dad6a479439ada609741ebebc4adaf23"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/sailfish-access-control/sailfish-access-control_git.bb
+++ b/recipes-nemomobile/sailfish-access-control/sailfish-access-control_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "sailfish access control, a thin wrapper around getuid and friends."
 HOMEPAGE = "https://git.merproject.org/mer-core/sailfish-access-control"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://glib/sailfishaccesscontrol.c;beginline=1;endline=17;md5=b6d1a1603875ba04da1967b348657dfa"
 
 SRC_URI = "git://github.com/sailfishos/sailfish-access-control.git;protocol=https;branch=master"

--- a/recipes-nemomobile/sailfish-access-control/sailfish-access-control_git.bb
+++ b/recipes-nemomobile/sailfish-access-control/sailfish-access-control_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://git.merproject.org/mer-core/sailfish-access-control"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://glib/sailfishaccesscontrol.c;beginline=1;endline=17;md5=b6d1a1603875ba04da1967b348657dfa"
 
-SRC_URI = "git://github.com/sailfishos/sailfish-access-control.git;protocol=https"
+SRC_URI = "git://github.com/sailfishos/sailfish-access-control.git;protocol=https;branch=master"
 SRCREV = "563353c325ff4f395e4de72da02d23a6587d55fb"
 PR = "r1"
 PV = "+git${SRCPV}"

--- a/recipes-nemomobile/sensorfw/sensorfw_git.bb
+++ b/recipes-nemomobile/sensorfw/sensorfw_git.bb
@@ -14,7 +14,7 @@ PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-inherit qmake5
+inherit qmake5 pkgconfig
 
 EXTRA_QMAKEVARS_PRE = "CONFIG+=autohybris"
 
@@ -32,7 +32,7 @@ do_install:append() {
     ln -s ../sensorfwd.service ${D}/lib/systemd/system/multi-user.target.wants/
 }
 
-DEPENDS += "qtbase"
+DEPENDS += "qtbase libhybris"
 
 FILES:${PN} += "/usr/lib/sensord-qt5/*.so /usr/lib/sensord-qt5/testing/*.so /lib/systemd/system"
 FILES:${PN}-dbg += "/usr/share/sensorfw-tests/ /usr/lib/sensord-qt5/.debug/ /usr/lib/sensord-qt5/testing/.debug/"

--- a/recipes-nemomobile/sensorfw/sensorfw_git.bb
+++ b/recipes-nemomobile/sensorfw/sensorfw_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/sensorfw"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
-SRC_URI = "git://github.com/sailfishos/sensorfw.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/sensorfw.git;protocol=https;branch=master \
            file://0001-Do-not-hide-stepcounter-by-default.patch \
            file://0002-Add-heart-rate-monitor-sensor-with-hybris-adaptor.patch \
            file://0003-Add-Wrist-gesture-sensor-via-libhybris-adaptor.patch \

--- a/recipes-nemomobile/sensorfw/sensorfw_git.bb
+++ b/recipes-nemomobile/sensorfw/sensorfw_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's sensorfw"
 HOMEPAGE = "https://github.com/sailfishos/sensorfw"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
 SRC_URI = "git://github.com/sailfishos/sensorfw.git;protocol=https;branch=master \

--- a/recipes-nemomobile/timed/timed/0001-Fixes-build.patch
+++ b/recipes-nemomobile/timed/timed/0001-Fixes-build.patch
@@ -1,24 +1,24 @@
-From 4d4218d62cac20771397d6d91830b9b7c5ff9ec6 Mon Sep 17 00:00:00 2001
+From 2f863e53cd717d927f340dc054e4712a8905877e Mon Sep 17 00:00:00 2001
 From: Florent Revest <revestflo@gmail.com>
 Date: Tue, 14 Jul 2015 12:07:59 +0200
-Subject: [PATCH 1/1] Fixes build
+Subject: [PATCH] Fixes build
 
 ---
  src/server/adaptor.h              |   1 +
- src/server/config.type.cpp        |  33 +++++++++++
+ src/server/config.type.cpp        |  37 ++++++++++
  src/server/config.type.h          |   5 ++
- src/server/customization.type.cpp |  23 ++++++++
+ src/server/customization.type.cpp |  23 ++++++
  src/server/customization.type.h   |   5 ++
- src/server/queue.type.cpp         | 115 ++++++++++++++++++++++++++++++++++++++
+ src/server/queue.type.cpp         | 115 ++++++++++++++++++++++++++++++
  src/server/queue.type.h           |   5 ++
- src/server/server.pro             |  12 +++-
- src/server/settings.type.cpp      |  59 +++++++++++++++++++
+ src/server/server.pro             |  10 ++-
+ src/server/settings.type.cpp      |  59 +++++++++++++++
  src/server/settings.type.h        |   5 ++
- src/server/timed-cust-rc.type.cpp |  25 +++++++++
+ src/server/timed-cust-rc.type.cpp |  25 +++++++
  src/server/timed-cust-rc.type.h   |   5 ++
- src/server/tzdata.type.cpp        |  53 ++++++++++++++++++
+ src/server/tzdata.type.cpp        |  53 ++++++++++++++
  src/server/tzdata.type.h          |   5 ++
- 14 files changed, 348 insertions(+), 3 deletions(-)
+ 14 files changed, 351 insertions(+), 2 deletions(-)
  create mode 100644 src/server/config.type.cpp
  create mode 100644 src/server/config.type.h
  create mode 100644 src/server/customization.type.cpp
@@ -33,10 +33,10 @@ Subject: [PATCH 1/1] Fixes build
  create mode 100644 src/server/tzdata.type.h
 
 diff --git a/src/server/adaptor.h b/src/server/adaptor.h
-index 7e25942..7c28921 100644
+index 6af39bd..253e4a6 100644
 --- a/src/server/adaptor.h
 +++ b/src/server/adaptor.h
-@@ -33,6 +33,7 @@
+@@ -35,6 +35,7 @@
  #include <QString>
  #include <QDBusAbstractAdaptor>
  #include <QDBusMessage>
@@ -271,10 +271,11 @@ index 0000000..aeb4a6a
 +iodata::validator * events_data_validator() ;
 +#endif
 diff --git a/src/server/server.pro b/src/server/server.pro
-index 0d82af6..24cf620 100644
+index dc1cc8f..e7a904a 100644
 --- a/src/server/server.pro
 +++ b/src/server/server.pro
-@@ -12,7 +12,7 @@ INCLUDEPATH += ../h
+@@ -10,7 +10,7 @@ VERSION = $$(TIMED_VERSION)
+ INCLUDEPATH += ../h
  
  QMAKE_LIBDIR_FLAGS += -L../lib -L../voland
 -LIBS += -ltimed-qt5 -ltimed-voland-qt5
@@ -282,8 +283,7 @@ index 0d82af6..24cf620 100644
  
  IODATA_TYPES = queue.type config.type settings.type customization.type tzdata.type
  
-
-@@ -72,7 +72,13 @@ SOURCES += \
+@@ -70,7 +70,13 @@ SOURCES += \
      ofonomodemmanager.cpp \
      modemwatcher.cpp \
      ofonoconstants.cpp \
@@ -486,6 +486,3 @@ index 0000000..4a2e83b
 +#include <iodata-qt5/validator>
 +iodata::validator * tzdata_validator() ;
 +#endif
--- 
-2.1.4
-

--- a/recipes-nemomobile/timed/timed/0002-Add-wakeup-event-for-use-with-ambient-mode.patch
+++ b/recipes-nemomobile/timed/timed/0002-Add-wakeup-event-for-use-with-ambient-mode.patch
@@ -1,7 +1,8 @@
-From 28c579dc30a7e5499d68a128ec479f9c064c1dd3 Mon Sep 17 00:00:00 2001
+From 51ffbf73829dcdb58d63a0ff5c721180e49595b6 Mon Sep 17 00:00:00 2001
 From: MagneFire <IDaNLContact@gmail.com>
 Date: Thu, 16 Jul 2020 22:51:52 +0200
 Subject: [PATCH] Add wakeup event for use with ambient mode. It seems like
+
  there is no easy way to get a callback from when an event occurs. The only
  way is using voland. Which, on AsteroidOS, is used by the alarmclock app. So
  scheduling an event for use with ambient mode would actually show the
@@ -14,6 +15,7 @@ Subject: [PATCH] Add wakeup event for use with ambient mode. It seems like
 
 Somehow we need to update the screen without triggering the alarmclock alarm dialog.
 The most straightforward way to do this is by adding a special `wakeup` type event, that doesn't trigger the voland event, but instead a new event.
+
 ---
  src/server/adaptor.h   |  1 +
  src/server/machine.cpp |  1 +
@@ -25,34 +27,34 @@ The most straightforward way to do this is by adding a special `wakeup` type eve
  7 files changed, 21 insertions(+), 2 deletions(-)
 
 diff --git a/src/server/adaptor.h b/src/server/adaptor.h
-index 7c28921..f7a6491 100644
+index 253e4a6..83afb40 100644
 --- a/src/server/adaptor.h
 +++ b/src/server/adaptor.h
-@@ -80,6 +80,7 @@ signals:
-   void settings_changed_1(bool) ;
+@@ -83,6 +83,7 @@ signals:
    void next_bootup_event(int next_boot_event, int next_non_boot_event);
+   void alarm_present_changed(bool present);
    void alarm_triggers_changed(Maemo::Timed::Event::Triggers);
 +  void wakeup_event();
-
+ 
  public slots:
-
+ 
 diff --git a/src/server/machine.cpp b/src/server/machine.cpp
-index 6977fb0..dee03cf 100644
+index 475f31d..16d904e 100644
 --- a/src/server/machine.cpp
 +++ b/src/server/machine.cpp
-@@ -116,6 +116,7 @@ machine_t::machine_t(const Timed *daemon) : timed(daemon)
+@@ -118,6 +118,7 @@ machine_t::machine_t(const Timed *daemon) : timed(daemon)
    state_armed->open() ;
-
+ 
    QObject::connect(state_dlg_wait, SIGNAL(voland_needed()), this, SIGNAL(voland_needed())) ;
 +  QObject::connect(state_dlg_wait, SIGNAL(wakeup_event()), this, SIGNAL(wakeup_event())) ;
-
+ 
    QObject::connect(state_dlg_wait, SIGNAL(closed()), state_dlg_requ, SLOT(open())) ;
    QObject::connect(state_dlg_wait, SIGNAL(closed()), state_dlg_user, SLOT(open())) ;
 diff --git a/src/server/machine.h b/src/server/machine.h
-index de0098f..314aba7 100644
+index 3f57355..27d7107 100644
 --- a/src/server/machine.h
 +++ b/src/server/machine.h
-@@ -101,6 +101,7 @@ Q_SIGNALS:
+@@ -109,6 +109,7 @@ Q_SIGNALS:
    void queue_to_be_saved() ;
    void voland_needed() ;
    void next_bootup_event(int, int);
@@ -61,10 +63,10 @@ index de0098f..314aba7 100644
    void alarm_present(bool present);
    void alarm_trigger(QMap<QString, QVariant> triggers);
 diff --git a/src/server/state.cpp b/src/server/state.cpp
-index 02a7d74..f840a74 100644
+index d4bde10..b9f1bcc 100644
 --- a/src/server/state.cpp
 +++ b/src/server/state.cpp
-@@ -738,8 +738,21 @@ void state_aborted_t::enter(event_t *e)
+@@ -740,8 +740,21 @@ void state_aborted_t::enter(event_t *e)
  void state_dlg_wait_t::enter(event_t *e)
  {
    e->flags |= EventFlags::In_Dialog ;
@@ -87,7 +89,7 @@ index 02a7d74..f840a74 100644
 +  }
    abstract_gate_state_t::enter(e) ;
  }
-
+ 
 diff --git a/src/server/state.h b/src/server/state.h
 index 92046e5..0e84ccb 100644
 --- a/src/server/state.h
@@ -101,11 +103,11 @@ index 92046e5..0e84ccb 100644
    Q_OBJECT ;
  } ;
 diff --git a/src/server/timed.cpp b/src/server/timed.cpp
-index 1d1179a..aa386d0 100644
+index 80b950a..498a609 100644
 --- a/src/server/timed.cpp
 +++ b/src/server/timed.cpp
-@@ -316,6 +316,7 @@ void Timed::init_create_event_machine()
-
+@@ -494,6 +494,7 @@ void Timed::init_create_event_machine()
+ 
    // Forward signal from am to DBUS via com_nokia_time DBUS adaptor
    QObject::connect(am, SIGNAL(next_bootup_event(int,int)), this, SIGNAL(next_bootup_event(int,int)));
 +  QObject::connect(am, SIGNAL(wakeup_event()), this, SIGNAL(wakeup_event()));
@@ -113,16 +115,14 @@ index 1d1179a..aa386d0 100644
    QObject::connect(this, SIGNAL(voland_registered()), am, SIGNAL(voland_registered())) ;
    QObject::connect(this, SIGNAL(voland_unregistered()), am, SIGNAL(voland_unregistered())) ;
 diff --git a/src/server/timed.h b/src/server/timed.h
-index e7cb2a7..2bdd62b 100644
+index 7a65592..0215210 100644
 --- a/src/server/timed.h
 +++ b/src/server/timed.h
-@@ -165,6 +165,7 @@ Q_SIGNALS:
-   void settings_changed(const Maemo::Timed::WallClock::Info &, bool system_time) ;
+@@ -145,6 +145,7 @@ Q_SIGNALS:
    void next_bootup_event(int next_boot_event, int next_non_boot_event);
+   void alarm_present_changed(bool present);
    void alarm_triggers_changed(Maemo::Timed::Event::Triggers);
 +  void wakeup_event();
    // void settings_changed_1(bool system_time) ;
  public:
    Timed(int ac, char **av) ;
---
-2.28.0

--- a/recipes-nemomobile/timed/timed_git.bb
+++ b/recipes-nemomobile/timed/timed_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/timed"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/sailfishos/timed.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/timed.git;protocol=https;branch=master \
     file://0001-Fixes-build.patch \
     file://0002-Add-wakeup-event-for-use-with-ambient-mode.patch \
     file://timed-qt5.conf \

--- a/recipes-nemomobile/timed/timed_git.bb
+++ b/recipes-nemomobile/timed/timed_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Nemomobile's time daemon"
 HOMEPAGE = "https://github.com/sailfishos/timed"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/sailfishos/timed.git;protocol=https;branch=master \

--- a/recipes-nemomobile/timed/timed_git.bb
+++ b/recipes-nemomobile/timed/timed_git.bb
@@ -13,7 +13,7 @@ PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-inherit qmake5 useradd
+inherit qmake5 useradd pkgconfig
 
 B = "${S}"
 
@@ -43,7 +43,7 @@ pkg_postinst:${PN}() {
 }
 
 PACKAGE_WRITE_DEPS = "libcap-native"
-DEPENDS += "pcre systemd tzdata libiodata-native libiodata qtbase sailfish-access-control"
+DEPENDS += "pcre libpcre systemd tzdata libiodata-native libiodata qtbase sailfish-access-control"
 RDEPENDS:${PN} += "libcap-bin tzdata"
 FILES:${PN} += "/usr/lib/ /usr/lib/systemd/user/default.target.wants/"
 FILES:${PN}-dev += "/usr/share/mkspecs"

--- a/recipes-nemomobile/timed/tzdata-timed_git.bb
+++ b/recipes-nemomobile/timed/tzdata-timed_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/tzdata-timed"
 LICENSE = "PD"
 LIC_FILES_CHKSUM = "file://legacy/copyright;md5=b103f1aabbbf321a0b6cf5056bca002e"
 
-SRC_URI = "git://github.com/sailfishos/tzdata-timed.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/tzdata-timed.git;protocol=https;branch=master \
            file://0001-Fixes-build-and-avoid-md5sum-mismatch-with-GMT-timez.patch"
 SRCREV = "5b8b301e6ea7ab55e46f67b3b0f3350241812852"
 PR = "r1"

--- a/recipes-nemomobile/usb-moded/usb-moded-qt5_git.bb
+++ b/recipes-nemomobile/usb-moded/usb-moded-qt5_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/libusb-moded-qt"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/qusbmoded.cpp;beginline=1;endline=32;md5=ffd9306b0b4c1289cd519527ddbc8d5a"
 
-SRC_URI = "git://github.com/sailfishos/libusb-moded-qt.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/libusb-moded-qt.git;protocol=https;branch=master \
     file://0001-src.pro-Make-sure-com.meego.usb_moded.xml-is-correct.patch \
     file://usb-moded-qt5.pc"
 SRCREV = "0544b73373bd0a9ec21ea05d1f8e4de22ba3e3fa"

--- a/recipes-nemomobile/usb-moded/usb-moded-qt5_git.bb
+++ b/recipes-nemomobile/usb-moded/usb-moded-qt5_git.bb
@@ -12,7 +12,7 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 DEPENDS += "qtbase usb-moded"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 do_install:append() {
     mv ${D}/include ${D}/usr/

--- a/recipes-nemomobile/usb-moded/usb-moded-qt5_git.bb
+++ b/recipes-nemomobile/usb-moded/usb-moded-qt5_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "usb_moded Qt bindings."
 HOMEPAGE = "https://github.com/sailfishos/libusb-moded-qt"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/qusbmoded.cpp;beginline=1;endline=32;md5=ffd9306b0b4c1289cd519527ddbc8d5a"
 
 SRC_URI = "git://github.com/sailfishos/libusb-moded-qt.git;protocol=https;branch=master \

--- a/recipes-nemomobile/usb-moded/usb-moded_git.bb
+++ b/recipes-nemomobile/usb-moded/usb-moded_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "This is a daemon which can hanlde setting different usb profiles with gadget drivers"
 HOMEPAGE = "https://github.com/philippedeswert/usb-moded"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=5f30f0716dfdd0d91eb439ebec522ec2"
 
 SRC_URI = "gitsm://github.com/sailfishos/usb-moded.git;protocol=https;branch=master \

--- a/recipes-nemomobile/usb-moded/usb-moded_git.bb
+++ b/recipes-nemomobile/usb-moded/usb-moded_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/philippedeswert/usb-moded"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=5f30f0716dfdd0d91eb439ebec522ec2"
 
-SRC_URI = "gitsm://github.com/sailfishos/usb-moded.git;protocol=https \
+SRC_URI = "gitsm://github.com/sailfishos/usb-moded.git;protocol=https;branch=master \
            file://0001-Correct-rndis-configfs-function-name.patch \
            file://0002-usb-modded-worker-Use-buteo-mtp-wrapper.patch \
            file://0003-usb-moded-Return-success-when-already-mounted.patch \

--- a/recipes-nemomobile/voicecall/voicecall_git.bb
+++ b/recipes-nemomobile/voicecall/voicecall_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/voicecall"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://plugins/providers/ofono/src/ofonovoicecallhandler.cpp;beginline=1;endline=20;md5=7f57bb9f2a19d976f63ad5deb007d7a2"
 
-SRC_URI = "git://github.com/sailfishos/voicecall.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/voicecall.git;protocol=https;branch=master \
            file://0001-Fixes-build.patch"
 SRCREV = "aa8876d6b0969a4e2d0bd9565e87967142b84792"
 PR = "r1"

--- a/recipes-nemomobile/voicecall/voicecall_git.bb
+++ b/recipes-nemomobile/voicecall/voicecall_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "voicecall is a daemon (and QML plugin) for implementing dialer UIs"
 HOMEPAGE = "https://github.com/sailfishos/voicecall"
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://plugins/providers/ofono/src/ofonovoicecallhandler.cpp;beginline=1;endline=20;md5=7f57bb9f2a19d976f63ad5deb007d7a2"
 
 SRC_URI = "git://github.com/sailfishos/voicecall.git;protocol=https;branch=master \

--- a/recipes-qt/qt5/kcalcore_git.bb
+++ b/recipes-qt/qt5/kcalcore_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/kcalcore"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
-SRC_URI = "git://github.com/sailfishos/kcalcore.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/kcalcore.git;protocol=https;branch=master \
         file://0001-Removes-unused-reference-to-a-host-include-directory.patch \
         file://0002-Disable-tests.patch"
 SRCREV = "2c6873c0478b87d54a84c3c3f0e9aead262b9d9d"

--- a/recipes-qt/qt5/kcalcore_git.bb
+++ b/recipes-qt/qt5/kcalcore_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Mer's Qt5 fork of KDE PIM 4's core component"
 HOMEPAGE = "https://github.com/sailfishos/kcalcore"
-LICENSE = "LGPL-2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
 SRC_URI = "git://github.com/sailfishos/kcalcore.git;protocol=https;branch=master \

--- a/recipes-qt/qt5/kcalcore_git.bb
+++ b/recipes-qt/qt5/kcalcore_git.bb
@@ -10,6 +10,6 @@ SRCREV = "2c6873c0478b87d54a84c3c3f0e9aead262b9d9d"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 DEPENDS += "qtbase timed libical bison-native"

--- a/recipes-qt/qt5/mkcal_git.bb
+++ b/recipes-qt/qt5/mkcal_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Mer's fork of KCal"
 HOMEPAGE = "https://github.com/sailfishos/mkcal"
-LICENSE = "LGPL-2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://src/mkcal_export.h;beginline=1;endline=20;md5=6b5a610cd22589226883c2df189ff891"
 
 SRC_URI = "git://github.com/sailfishos/mkcal.git;protocol=https;branch=master \

--- a/recipes-qt/qt5/mkcal_git.bb
+++ b/recipes-qt/qt5/mkcal_git.bb
@@ -11,6 +11,6 @@ SRCREV = "bccf4e2f28c65006c2cfa8a36acc584a59bcf501"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 DEPENDS += "qtbase kcalcore timed libical sqlite3 util-linux"

--- a/recipes-qt/qt5/mkcal_git.bb
+++ b/recipes-qt/qt5/mkcal_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/mkcal"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://src/mkcal_export.h;beginline=1;endline=20;md5=6b5a610cd22589226883c2df189ff891"
 
-SRC_URI = "git://github.com/sailfishos/mkcal.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/mkcal.git;protocol=https;branch=master \
            file://0001-Removes-unused-reference-to-host-include-directories.patch \
            file://0002-Fixes-an-incorrect-returned-variable.patch \
            file://0003-Disable-tests-and-docs.patch"

--- a/recipes-qt/qt5/nemo-qtmultimedia-plugins_git.bb
+++ b/recipes-qt/qt5/nemo-qtmultimedia-plugins_git.bb
@@ -9,7 +9,7 @@ SRCREV = "3f8f24be26a65fdc002c66d93ea115ba53afbc20"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 DEPENDS += "qtmultimedia nemo-gst-interfaces"
 

--- a/recipes-qt/qt5/nemo-qtmultimedia-plugins_git.bb
+++ b/recipes-qt/qt5/nemo-qtmultimedia-plugins_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/sailfishos/nemo-qtmultimedia-plugins"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://src/videotexturebackend/videotexturebackend.cpp;beginline=1;endline=31;md5=345009371abdfb1df57032e6f41dbd26"
 
-SRC_URI = "git://github.com/sailfishos/nemo-qtmultimedia-plugins.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/nemo-qtmultimedia-plugins.git;protocol=https;branch=master \
            file://0001-Use-QGstTools-as-a-private-Qt-module-instead-of-a-li.patch"
 SRCREV = "3f8f24be26a65fdc002c66d93ea115ba53afbc20"
 PR = "r1"

--- a/recipes-qt/qt5/nemo-qtmultimedia-plugins_git.bb
+++ b/recipes-qt/qt5/nemo-qtmultimedia-plugins_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "QtMultimedia QML VideoOutput backend for GStreamer NemoVideoTexture interface"
 HOMEPAGE = "https://github.com/sailfishos/nemo-qtmultimedia-plugins"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/videotexturebackend/videotexturebackend.cpp;beginline=1;endline=31;md5=345009371abdfb1df57032e6f41dbd26"
 
 SRC_URI = "git://github.com/sailfishos/nemo-qtmultimedia-plugins.git;protocol=https;branch=master \

--- a/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
+++ b/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
@@ -18,7 +18,7 @@ SRC_URI = "git://github.com/mer-hybris/qt5-qpa-hwcomposer-plugin;protocol=https;
 S = "${WORKDIR}/git/hwcomposer"
 SRCREV = "e9b72254c368d82961913f1a28134f472076f3d6"
 
-inherit qmake5
+inherit qmake5 pkgconfig
 
 # WARNING: The recipe qt5-qpa-hwcomposer-plugin is trying to install files into a shared area when those files already exist. Those files and their manifest location are:
 #   /OE/build/owpb/webos-ports/tmp-eglibc/sysroots/tenderloin/usr/lib/cmake/Qt5Gui/Qt5Gui_QEglFSIntegrationPlugin.cmake

--- a/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
+++ b/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
@@ -13,7 +13,7 @@ RDEPENDS:${PN} += " qtscenegraph-adaptation "
 # Android version we select per machine
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-SRC_URI = "git://github.com/mer-hybris/qt5-qpa-hwcomposer-plugin;protocol=https \
+SRC_URI = "git://github.com/mer-hybris/qt5-qpa-hwcomposer-plugin;protocol=https;branch=master \
         file://0001-Add-ambient-mode-display-support.patch;striplevel=2 "
 S = "${WORKDIR}/git/hwcomposer"
 SRCREV = "e9b72254c368d82961913f1a28134f472076f3d6"

--- a/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
+++ b/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "This QPA plugin allows rendering on top of libhybris-based hwcomposer EGL \
 platforms. The hwcomposer API is specific to a given Droid release, and \
 sometimes also SoC type (generic, qcom, exynos4, ...)."
-LICENSE = "LGPL-2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://hwcomposer_backend.cpp;beginline=1;endline=40;md5=09c08382077db2dbc01b1b5536ec6665"
 
 PV = "5.15.0+gitr${SRCPV}"

--- a/recipes-qt/qt5/qtscenegraph-adaptation_git.bb
+++ b/recipes-qt/qt5/qtscenegraph-adaptation_git.bb
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 DESCRIPTION = "System specific changes for the Qt Quick Scene Graph."
-LICENSE = "LGPL-2.1 & GPL-3.0"
+LICENSE = "LGPL-2.1-only & GPL-3.0-only"
 LIC_FILES_CHKSUM = " \
     file://LICENSE.GPL;md5=d32239bcb673463ab874e80d47fae504 \
     file://LICENSE.LGPL;md5=4193e7f1d47a858f6b7c0f1ee66161de \

--- a/recipes-qt/qt5/qtscenegraph-adaptation_git.bb
+++ b/recipes-qt/qt5/qtscenegraph-adaptation_git.bb
@@ -11,7 +11,7 @@ SRCREV = "13394b94c6c406fafdd7a95edc12938efeb4d66a"
 
 DEPENDS = "qtbase libhybris qtwayland virtual/android-headers qtdeclarative"
 
-SRC_URI = "git://github.com/sailfishos/qtscenegraph-adaptation.git;protocol=https \
+SRC_URI = "git://github.com/sailfishos/qtscenegraph-adaptation.git;protocol=https;branch=master \
         file://0001-customcontext-Adapt-for-Qt-5.8.patch \
         file://0002-Fix-build-for-Qt-5.8.patch \
         file://0003-Fix-build-on-Qt-5.10.patch \

--- a/recipes-qt/qt5/qtsensors_git.bbappend
+++ b/recipes-qt/qt5/qtsensors_git.bbappend
@@ -1,4 +1,4 @@
 EXTRA_QMAKEVARS_PRE = "CONFIG+=sensorfw"
 DEPENDS+="sensorfw"
-SRC_URI = "git://github.com/AsteroidOS/qtsensors.git;protocol=https"
+SRC_URI = "git://github.com/AsteroidOS/qtsensors.git;protocol=https;branch=master"
 SRCREV = "${AUTOREV}"

--- a/recipes-support/farstream/farstream_git.bb
+++ b/recipes-support/farstream/farstream_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "The Farstream (formerly Farsight) project is an effort to create a framework to deal with all known audio/video conferencing protocols"
 HOMEPAGE = "https://freedesktop.org/wiki/Software/Farstream/"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=fbc093901857fcd118f065f900982c24"
 
 SRC_URI = "https://freedesktop.org/software/farstream/releases/farstream/farstream-0.2.8.tar.gz"


### PR DESCRIPTION
This adds support for Yocto Kirkstone (4.0).
Most of these changes are based on the migration guide: https://docs.yoctoproject.org/dev/migration-guides/migration-4.0.html

For now, I've only testes this on `sturgeon` and compiled for `tetra`.
Edit: Now also successfully compiles the SDK.