### PR TITLE
geoclue-provider-hybris: Inherit pkgconfig to fix build issue.

### DIFF
--- a/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris_git.bb
+++ b/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris_git.bb
@@ -10,7 +10,7 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 DEPENDS += "geoclue libhybris libconnman-qt5 libqofono qofonoext nemo-qml-plugin-systemsettings"
-inherit qmake5
+inherit qmake5 pkgconfig
 
 do_install:append() {
     chmod 04755 ${D}/usr/libexec/geoclue-hybris


### PR DESCRIPTION
Fixes: `Project ERROR: libhardware development package not found`

This issue occurred when building the toolchain.