### PR TITLE
ngfd-plugin-droid-vibrator: Fix dependency issue.

### DIFF
--- a/recipes-nemomobile/ngfd/ngfd-plugin-droid-vibrator_git.bb
+++ b/recipes-nemomobile/ngfd/ngfd-plugin-droid-vibrator_git.bb
@@ -2,6 +2,7 @@ SUMMARY = "Nemomobile's non graphical feedback daemon's hybris plugin"
 HOMEPAGE = "https://github.com/mer-hybris/ngfd-plugin-droid-vibrator"
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 FILESEXTRAPATHS:append := "${THISDIR}/${PN}:"
 SRC_URI = "git://github.com/mer-hybris/ngfd-plugin-droid-vibrator.git;protocol=https;branch=master \

--- a/recipes-nemomobile/ngfd/ngfd-plugin-droid-vibrator_git.bb
+++ b/recipes-nemomobile/ngfd/ngfd-plugin-droid-vibrator_git.bb
@@ -12,7 +12,7 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 B = "${S}"
 
-DEPENDS += "ngfd libhybris"
+DEPENDS += "ngfd libhybris virtual/android-headers"
 
 do_install:append () {
     install -d ${D}/usr/share/ngfd/plugins.d/


### PR DESCRIPTION
The ngfd droid backend uses the Android headers (version specifically) to figure out which Android API to use.
These headers existed as part of the libhybris dependency, but a change of machine would not always trigger a sysroot update because there's no hard dependency on the android-headers package.

This fixes the issue where sometimes the vibrator would not work for some watches.

This issue was reported by @dodoradio, https://github.com/AsteroidOS/meta-smartwatch/issues/90 and https://github.com/AsteroidOS/meta-smartwatch/issues/91.