### PR TITLE
firmwared: Add /firmware/image to the firmware search path.

### DIFF
--- a/recipes-core/firmwared/firmwared/firmwared.service
+++ b/recipes-core/firmwared/firmwared/firmwared.service
@@ -3,7 +3,7 @@ Description=Linux Firmware Loader Daemon
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/firmwared -d /vendor/firmware:/system/etc/firmware:/etc/firmware:/lib/firmware/updates/:/lib/firmware
+ExecStart=/usr/bin/firmwared -d /vendor/firmware:/system/etc/firmware:/etc/firmware:/lib/firmware/updates/:/lib/firmware:/firmware/image
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
Android/WearOS often provides a dedicated partition for firmware files.
This is generally mounted under `/firmware`.
The initrdscripts already provides the logic to mount the firmware partition via the `firmware_partition` variable.

This is also need by https://github.com/AsteroidOS/meta-smartwatch/pull/95 as it copies the touchscreen firmware files to `/firmware`.