### PR TITLE
Add more information to os-release

### DIFF
--- a/recipes-asteroid/asteroid-machine-config/asteroid-machine-config_1.0.bb
+++ b/recipes-asteroid/asteroid-machine-config/asteroid-machine-config_1.0.bb
@@ -10,10 +10,14 @@ def display_variables(d):
 def capability_variables(d):
     return ["MACHINE_HAS_WLAN", "MACHINE_HAS_SPEAKER"]
 
+def identity_variables(d):
+    return ["MACHINE"]
+
 python do_generate_config () {
     machine_vars = {
         "Display": display_variables(d),
-        "Capabilities": capability_variables(d)
+        "Capabilities": capability_variables(d),
+        "Identity": identity_variables(d)
     }
 
     from configparser import ConfigParser
@@ -26,6 +30,8 @@ python do_generate_config () {
             v = var[len("MACHINE_"):]
             if v.startswith(key.upper() + "_"):
                 v = v[len(key.upper() + "_"):]
+            if not v:
+                v = var
             if d.getVar(var) is not None:
                 config.set(key, v, str(d.getVar(var)))
 

--- a/recipes-core/os-release/os-release.bbappend
+++ b/recipes-core/os-release/os-release.bbappend
@@ -1,0 +1,6 @@
+OS_RELEASE_FIELDS += "\
+    BUILD_ID LOGO HOME_URL \
+"
+OS_RELEASE_UNQUOTED_FIELDS += " LOGO"
+HOME_URL = "https://asteroidos.org/"
+LOGO = "logo-asteroidos"


### PR DESCRIPTION
This adds several useful fields to /etc/os-release so that, for
instance, on sturgeon, the new values look like this:
BUILD_ID="20220726172548"
DEFAULT_HOSTNAME="sturgeon"
LOGO=logo-asteroidos
HOME_URL="https://asteroidos.org/"

These fields, their encodings and meanings are documented here:
https://www.freedesktop.org/software/systemd/man/os-release.html

Signed-off-by: Ed Beroset <beroset@ieee.org>