### PR TITLE
Update libaccounts-qt to version 1.16

### DIFF
--- a/recipes-nemomobile/libaccounts/libaccounts-qt5_git.bb
+++ b/recipes-nemomobile/libaccounts/libaccounts-qt5_git.bb
@@ -4,9 +4,8 @@ LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=243b725d71bb5df4a1e5920b344b86ad"
 
 SRC_URI = "git://gitlab.com/accounts-sso/libaccounts-qt.git;protocol=https;branch=master"
-SRCREV = "f4d8af8dffb461a0eff9f03925fe6dbab9f1c1d2"
-PR = "r1"
-PV = "+git${SRCPV}"
+SRCREV = "525ec684cfa8d234f797d7e49e21c476eea04d8e"
+PV = "1.16"
 S = "${WORKDIR}/git"
 inherit qmake5 pkgconfig
 


### PR DESCRIPTION
This is one of the steps required for an update to a working calendar
import for the watch.

Signed-off-by: Ed Beroset <beroset@ieee.org>