### PR TITLE
Add the usb-moded file location for serial number

### DIFF
--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-systemsettings/0006-Add-file-to-the-places-searched-for-a-serial-number.patch
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-systemsettings/0006-Add-file-to-the-places-searched-for-a-serial-number.patch
@@ -1,0 +1,25 @@
+From 1c61ec5a3457047987ca5ae709762482269d0ea4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tomi=20Lepp=C3=A4nen?= <tomi.leppanen@jolla.com>
+Date: Fri, 16 Nov 2018 10:41:00 +0200
+Subject: [PATCH] [aboutsettings] Add source for serial number. Fixes JB#38513
+
+Add /sys/class/android_usb/android0/iSerial as a source for serial
+number information. usb-moded sets up this information so it should be
+always available.
+---
+ src/aboutsettings.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/aboutsettings.cpp b/src/aboutsettings.cpp
+index d2b3d65..4b895f1 100644
+--- a/src/aboutsettings.cpp
++++ b/src/aboutsettings.cpp
+@@ -171,6 +171,8 @@ QString AboutSettings::serial() const
+     serialFiles
+         // This file is specific to the Jolla Tablet;
+         << "/config/serial/serial.txt"
++        // usb-moded sets up the serial number here.
++        << "/sys/class/android_usb/android0/iSerial"
+         // Some devices have serialno in this path.
+         << "/sys/firmware/devicetree/base/firmware/android/serialno";
+ 

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-systemsettings_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-systemsettings_git.bb
@@ -8,7 +8,9 @@ SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-systemsettings.git;protoc
     file://0001-Disable-SSU-dependency.patch \
     file://0002-languagemodel-install-languages-in-usr-share-support.patch \
     file://0004-LanguageModel-Notify-asteroid-launcher-of-locale-cha.patch \
-    file://0005-Remove-certificatemodel-and-developermodesettings.patch"
+    file://0005-Remove-certificatemodel-and-developermodesettings.patch \
+    file://0006-Add-file-to-the-places-searched-for-a-serial-number.patch \
+    "
 SRCREV = "8ee508e5370487afef1826e2ebaff0e44e604300"
 PR = "r1"
 PV = "+git${SRCPV}"


### PR DESCRIPTION
This patches nemo-qml-plugin-systemsettings to allow that plugin to
correctly fetch the serial number for AsteroidOS and parallels a change
already made to upstream in commit
96b6ae08c6ce47dbcb6625227905eda21383e2bc.

Signed-off-by: Ed Beroset <beroset@ieee.org>