### PR TITLE
asteroid-compass: Keep translation files.

### DIFF
--- a/recipes-asteroid/asteroid-compass/asteroid-compass_git.bb
+++ b/recipes-asteroid/asteroid-compass/asteroid-compass_git.bb
@@ -12,8 +12,4 @@ inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"
 RDEPENDS:${PN} += "qtsensors qtsensors-qmlplugins qtsensors-plugins"
-
-do_install:append() {
-    # This app only uses translations for the desktop shortcut.
-    rm -rvf ${D}/usr/share/translations/
-}
+FILES:${PN} += "/usr/share/translations/"


### PR DESCRIPTION
Since the recent redesign we now add a calibration text which can be translated.
