### PR TITLE
geoclue-provider-hybris: Bump SRCREV to 0.2.35 and split recipe.

### DIFF
--- a/recipes-nemomobile/geoclue-providers/files/0001-pri-Fix-host-contamination-path-issue.patch
+++ b/recipes-nemomobile/geoclue-providers/files/0001-pri-Fix-host-contamination-path-issue.patch
@@ -1,0 +1,29 @@
+From ca484f3aeb8511e4bb68ef32b2c677d557ed7a3b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Sat, 10 Sep 2022 23:20:38 +0200
+Subject: [PATCH] pri: Fix host contamination path issue.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ geoclue-providers-hybris.pri | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/geoclue-providers-hybris.pri b/geoclue-providers-hybris.pri
+index 78d9d7d..16ad290 100644
+--- a/geoclue-providers-hybris.pri
++++ b/geoclue-providers-hybris.pri
+@@ -36,7 +36,7 @@ system_dbus_conf.path = /etc/dbus-1/system.d
+ systemd_dbus_service.files = geoclue-providers-hybris.service
+ systemd_dbus_service.path = /usr/lib/systemd/user
+ 
+-systemd_dbus_service_symlink.path = .
++systemd_dbus_service_symlink.path = /usr/lib/systemd/user/
+ systemd_dbus_service_symlink.commands = ln -s geoclue-providers-hybris.service ${INSTALL_ROOT}/usr/lib/systemd/user/dbus-org.freedesktop.Geoclue.Providers.Hybris.service
+ 
+ geoclue_provider.files = geoclue-hybris.provider
+-- 
+2.37.3
+

--- a/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris-binder_git.bb
+++ b/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris-binder_git.bb
@@ -1,0 +1,8 @@
+SUMMARY = "Binder libhybris backend for GeoClue"
+HOMEPAGE = "https://github.com/mer-hybris/geoclue-providers-hybris"
+
+QMAKE_PROFILES = "${S}/binder/binderlocationbackend.pro"
+
+require geoclue-provider-hybris.inc
+
+DEPENDS += "libgbinder glib-2.0 libglibutil"

--- a/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris-hal_git.bb
+++ b/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris-hal_git.bb
@@ -1,0 +1,6 @@
+SUMMARY = "HAL libhybris backend for GeoClue"
+HOMEPAGE = "https://github.com/mer-hybris/geoclue-providers-hybris"
+
+QMAKE_PROFILES = "${S}/hal/hallocationbackend.pro"
+
+require geoclue-provider-hybris.inc

--- a/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris.inc
+++ b/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris.inc
@@ -3,8 +3,9 @@ HOMEPAGE = "https://github.com/mer-hybris/geoclue-providers-hybris"
 LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/mer-hybris/geoclue-providers-hybris.git;protocol=https;branch=master"
-SRCREV = "8775abcf9983abb4b8be28ad43f7a193edac5605"
+SRC_URI = "git://github.com/mer-hybris/geoclue-providers-hybris.git;protocol=https;branch=master \
+    file://0001-pri-Fix-host-contamination-path-issue.patch"
+SRCREV = "0.2.35"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
@@ -12,8 +13,11 @@ S = "${WORKDIR}/git"
 DEPENDS += "geoclue libhybris libconnman-qt5 libqofono qofonoext nemo-qml-plugin-systemsettings"
 inherit qmake5 pkgconfig
 
+# Ensures that the root sources can be found.
+B = "${S}"
+
 do_install:append() {
     chmod 04755 ${D}/usr/libexec/geoclue-hybris
 }
 
-FILES:${PN} += "/usr/share/dbus-1 /usr/share/geoclue-providers"
+FILES:${PN} += "/usr/share/dbus-1 /usr/share/geoclue-providers /usr/lib/systemd/user"


### PR DESCRIPTION
From now on provide a HAL (gps.x.so) and a binder (/dev/hwbinder) version of the `geoclue-provider-hybris`.

Before merging this requires changes to https://github.com/AsteroidOS/meta-smartwatch which I'll create a PR for if this is all good.

Additionally, this work depends on https://github.com/AsteroidOS/meta-asteroid/pull/112.