### PR TITLE
qt5-qpa-hwcomposer-plugin: Add Always-on-Display support for hwc2.

### DIFF
--- a/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0001-Add-ambient-mode-display-support.patch
+++ b/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0001-Add-ambient-mode-display-support.patch
@@ -1,24 +1,32 @@
-From ea68e0623472bd7a8b003248cb68f026aa2b04ac Mon Sep 17 00:00:00 2001
-From: MagneFire <IDaNLContact@gmail.com>
-Date: Fri, 8 Jan 2021 17:10:03 +0100
-Subject: [PATCH] Add ambient mode display support. Add ability to keep the
- screen on while in deep sleep mode. This is achieved by setting the power
- mode to HWC_POWER_MODE_DOZE_SUSPEND. We need PowerHAL to setInteractive based
- on display state, this is required for some platforms to make ambient mode
- work.
+From 78d65290f31aea9b3fceb922befcabbc8af6d4e5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Mon, 5 Sep 2022 22:35:07 +0200
+Subject: [PATCH] Add ambient mode display support.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
+Add ability to keep the screen on while in deep sleep mode.
+This is achieved by setting the power mode to HWC_POWER_MODE_DOZE_SUSPEND.
+We need PowerHAL to setInteractive based on display state, this is required for some platforms to make ambient mode work.
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
 ---
- hwcomposer/hwcomposer_backend.cpp     | 24 +++++++++++++++++--
- hwcomposer/hwcomposer_backend.h       |  4 ++++
- hwcomposer/hwcomposer_backend_v11.cpp | 33 +++++++++++++++++++++++----
- hwcomposer/hwcomposer_backend_v11.h   |  9 +++++++-
- hwcomposer/hwcomposer_context.cpp     | 16 ++++++++++++-
+ hwcomposer/hwcomposer_backend.cpp     | 39 ++++++++++++++++++++++-----
+ hwcomposer/hwcomposer_backend.h       |  5 ++++
+ hwcomposer/hwcomposer_backend_v10.cpp | 11 +++++++-
+ hwcomposer/hwcomposer_backend_v10.h   |  3 ++-
+ hwcomposer/hwcomposer_backend_v11.cpp | 26 +++++++++++++++---
+ hwcomposer/hwcomposer_backend_v11.h   |  7 ++++-
+ hwcomposer/hwcomposer_backend_v20.cpp | 17 ++++++++++--
+ hwcomposer/hwcomposer_backend_v20.h   |  7 ++++-
+ hwcomposer/hwcomposer_context.cpp     | 16 ++++++++++-
  hwcomposer/hwcomposer_context.h       |  3 +++
  hwcomposer/qeglfsintegration.cpp      |  6 +++++
- 7 files changed, 87 insertions(+), 8 deletions(-)
+ 11 files changed, 123 insertions(+), 17 deletions(-)
 
 diff --git a/hwcomposer/hwcomposer_backend.cpp b/hwcomposer/hwcomposer_backend.cpp
-index 69506c4..643714a 100644
+index f57a576..a997553 100644
 --- a/hwcomposer/hwcomposer_backend.cpp
 +++ b/hwcomposer/hwcomposer_backend.cpp
 @@ -75,6 +75,7 @@ HwComposerBackend::create()
@@ -28,15 +36,11 @@ index 69506c4..643714a 100644
 +    power_module_t *pwr_module = NULL;
      void *libminisf;
      void (*startMiniSurfaceFlinger)(void) = NULL;
-
-@@ -100,7 +101,26 @@ HwComposerBackend::create()
-     if (startMiniSurfaceFlinger) {
- 	startMiniSurfaceFlinger();
-     } else {
--	fprintf(stderr, "libminisf is incompatible or missing. Can not possibly start the SurfaceFlinger service. If you're experiencing troubles with media try updating droidmedia (and/or this plugin).");
-+	fprintf(stderr, "libminisf is incompatible or missing. Can not possibly start the SurfaceFlinger service. If you're experiencing troubles with media try updating droidmedia (and/or this plugin).\n");
-+    }
-+
+ 
+@@ -103,6 +104,25 @@ HwComposerBackend::create()
+         fprintf(stderr, "libminisf is incompatible or missing. Can not possibly start the SurfaceFlinger service. If you're experiencing troubles with media try updating droidmedia (and/or this plugin).");
+     }
+ 
 +    // Open power module for setting interactive state based on screen on/off.
 +    if (!hw_get_module(POWER_HARDWARE_MODULE_ID, (const hw_module_t **)(&pwr_module))) {
 +        pwr_module->init(pwr_module);
@@ -54,80 +58,174 @@ index 69506c4..643714a 100644
 +        pwr_module->powerHint(pwr_module, POWER_HINT_INTERACTION, NULL);
 +    } else {
 +        fprintf(stderr, "PowerHAL is missing or not working, display doze mode may not work\n");
-     }
-
++    }
++
      // Open hardware composer
-@@ -166,7 +186,7 @@ HwComposerBackend::create()
+     if (hw_get_module(HWC_HARDWARE_MODULE_ID, (const hw_module_t **)(&hwc_module)) == 0) {
+         fprintf(stderr, "== hwcomposer module ==\n");
+@@ -131,7 +151,7 @@ HwComposerBackend::create()
+         if ((hwc_device->version == HWC_DEVICE_API_VERSION_0_1) ||
+             (hwc_device->version == HWC_DEVICE_API_VERSION_0_2) ||
+             (hwc_device->version == HWC_DEVICE_API_VERSION_0_3)) {
+-            return new HwComposerBackend_v0(hwc_module, hwc_device, libminisf);
++            return new HwComposerBackend_v0(hwc_module, hwc_device, pwr_module, libminisf);
+         }
  #endif
-             // HWC_NUM_DISPLAY_TYPES is the actual size of the array, otherwise
-             // underrun/overruns happen
--            return new HwComposerBackend_v11(hwc_module, hwc_device, libminisf, HWC_NUM_DISPLAY_TYPES);
-+            return new HwComposerBackend_v11(hwc_module, hwc_device, pwr_module, libminisf, HWC_NUM_DISPLAY_TYPES);
-             break;
+ 
+@@ -141,11 +161,11 @@ HwComposerBackend::create()
+             case HWC_DEVICE_API_VERSION_0_1:
+             case HWC_DEVICE_API_VERSION_0_2:
+             case HWC_DEVICE_API_VERSION_0_3:
+-                return new HwComposerBackend_v0(hwc_module, hwc_device, libminisf);
++                return new HwComposerBackend_v0(hwc_module, hwc_device, pwr_module, libminisf);
+ #endif
+ #ifdef HWC_DEVICE_API_VERSION_1_0
+             case HWC_DEVICE_API_VERSION_1_0:
+-                return new HwComposerBackend_v10(hwc_module, hwc_device, libminisf);
++                return new HwComposerBackend_v10(hwc_module, hwc_device, pwr_module, libminisf);
+ #endif /* HWC_DEVICE_API_VERSION_1_0 */
+ #ifdef HWC_PLUGIN_HAVE_HWCOMPOSER1_API
+             case HWC_DEVICE_API_VERSION_1_1:
+@@ -163,11 +183,11 @@ HwComposerBackend::create()
+ #endif
+                 // HWC_NUM_DISPLAY_TYPES is the actual size of the array, otherwise
+                 // underrun/overruns happen
+-                return new HwComposerBackend_v11(hwc_module, hwc_device, libminisf, HWC_NUM_DISPLAY_TYPES);
++                return new HwComposerBackend_v11(hwc_module, hwc_device, pwr_module, libminisf, HWC_NUM_DISPLAY_TYPES);
  #endif /* HWC_PLUGIN_HAVE_HWCOMPOSER1_API */
  #ifdef HWC_PLUGIN_HAVE_HWCOMPOSER2_API
-diff --git a/hwcomposer/hwcomposer_backend.h b/hwcomposer/hwcomposer_backend.h
-index 77c0b88..9d876e9 100644
---- a/hwcomposer/hwcomposer_backend.h
-+++ b/hwcomposer/hwcomposer_backend.h
-@@ -49,6 +49,7 @@
- #include <android-config.h>
- #include <hardware/hardware.h>
- #include <hardware/hwcomposer.h>
-+#include <hardware/power.h>
-
- #include <EGL/egl.h>
- #include <EGL/eglext.h>
-@@ -107,6 +108,8 @@ public:
-     virtual EGLNativeWindowType createWindow(int width, int height) = 0;
-     virtual void destroyWindow(EGLNativeWindowType window) = 0;
-     virtual void swap(EGLNativeDisplayType display, EGLSurface surface) = 0;
-+    virtual bool ambientModeSupport() {return false;}
-+    virtual void ambientModeEnabled(bool enable) {Q_UNUSED(enable);}
-     virtual void sleepDisplay(bool sleep) = 0;
-     virtual float refreshRate() = 0;
-
-@@ -119,6 +122,7 @@ protected:
-     virtual ~HwComposerBackend();
-
-     hw_module_t *hwc_module;
-+    power_module_t *pwr_module;
-     void *libminisf;
- };
-
-diff --git a/hwcomposer/hwcomposer_backend_v11.cpp b/hwcomposer/hwcomposer_backend_v11.cpp
-index 23e51ab..8f158cd 100644
---- a/hwcomposer/hwcomposer_backend_v11.cpp
-+++ b/hwcomposer/hwcomposer_backend_v11.cpp
-@@ -178,10 +178,11 @@ void HWComposer::present(HWComposerNativeWindowBuffer *buffer)
-     }
- }
-
--HwComposerBackend_v11::HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, void *libminisf, int num_displays)
-+HwComposerBackend_v11::HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, power_module_t *pw_device, void *libminisf, int num_displays)
-     : HwComposerBackend(hwc_module, libminisf)
-     , hwc_device((hwc_composer_device_1_t *)hw_device)
-     , hwc_list(NULL)
-+    , pwr_device(pw_device)
-     , hwc_mList(NULL)
-     , num_displays(num_displays)
-     , m_displayOff(true)
-@@ -346,6 +347,13 @@ HwComposerBackend_v11::swap(EGLNativeDisplayType display, EGLSurface surface)
+             case HWC_DEVICE_API_VERSION_2_0:
+-                return new HwComposerBackend_v20(NULL, libminisf);
++                return new HwComposerBackend_v20(NULL, pwr_module, libminisf);
  #endif
+             default:
+                 fprintf(stderr, "Unknown hwcomposer API: 0x%x/0x%x/0x%x\n",
+@@ -180,7 +200,7 @@ HwComposerBackend::create()
+ #ifdef HWC_PLUGIN_HAVE_HWCOMPOSER2_API
+     else {
+         // Create hwc2 backend directly if opening hardware module fails
+-        return new HwComposerBackend_v20(NULL, libminisf);
++        return new HwComposerBackend_v20(NULL, pwr_module, libminisf);
+     }
+ #endif
+ 
+@@ -188,6 +208,13 @@ HwComposerBackend::create()
+     return NULL;
  }
-
-+void HwComposerBackend_v11::ambientModeEnabled(bool enable)
+ 
++void
++HwComposerBackend::ambientModeEnabled(bool enable)
 +{
 +    if (ambientModeSupport()) {
 +        m_ambientMode = enable;
 +    }
 +}
-+
  void
- HwComposerBackend_v11::sleepDisplay(bool sleep)
+ HwComposerBackend::destroy(HwComposerBackend *backend)
  {
-@@ -359,16 +367,33 @@ HwComposerBackend_v11::sleepDisplay(bool sleep)
-
+diff --git a/hwcomposer/hwcomposer_backend.h b/hwcomposer/hwcomposer_backend.h
+index 68169b7..84b17ba 100644
+--- a/hwcomposer/hwcomposer_backend.h
++++ b/hwcomposer/hwcomposer_backend.h
+@@ -50,6 +50,7 @@
+ #include <android-config.h>
+ #include <hardware/hardware.h>
+ #include <hardware/hwcomposer.h>
++#include <hardware/power.h>
+ 
+ #include <EGL/egl.h>
+ #include <EGL/eglext.h>
+@@ -108,6 +109,8 @@ public:
+     virtual EGLNativeWindowType createWindow(int width, int height) = 0;
+     virtual void destroyWindow(EGLNativeWindowType window) = 0;
+     virtual void swap(EGLNativeDisplayType display, EGLSurface surface) = 0;
++    virtual bool ambientModeSupport() {return false;}
++    virtual void ambientModeEnabled(bool enable);
+     virtual void sleepDisplay(bool sleep) = 0;
+     virtual float refreshRate() = 0;
+ 
+@@ -119,7 +122,9 @@ protected:
+     HwComposerBackend(hw_module_t *hwc_module, void *libmsf);
+     virtual ~HwComposerBackend();
+ 
++    bool m_ambientMode;
+     hw_module_t *hwc_module;
++    power_module_t *pwr_module;
+     void *libminisf;
+ };
+ 
+diff --git a/hwcomposer/hwcomposer_backend_v10.cpp b/hwcomposer/hwcomposer_backend_v10.cpp
+index 21648fe..771b09e 100644
+--- a/hwcomposer/hwcomposer_backend_v10.cpp
++++ b/hwcomposer/hwcomposer_backend_v10.cpp
+@@ -135,9 +135,10 @@ static hwc_procs_t global_procs = {
+ };
+ 
+ 
+-HwComposerBackend_v10::HwComposerBackend_v10(hw_module_t *hwc_module, hw_device_t *hw_device, void *libminisf)
++HwComposerBackend_v10::HwComposerBackend_v10(hw_module_t *hwc_module, hw_device_t *hw_device, power_module_t *pw_device, void *libminisf)
+     : HwComposerBackend(hwc_module, libminisf)
+     , hwc_device((hwc_composer_device_1_t *)hw_device)
++    , pwr_device(pw_device)
+     , hwc_list(NULL)
+     , hwc_mList(NULL)
+     , hwc_numDisplays(1) // "For HWC 1.0, numDisplays will always be one."
+@@ -255,8 +256,16 @@ HwComposerBackend_v10::sleepDisplay(bool sleep)
+     if (sleep) {
+         HWC_PLUGIN_EXPECT_ZERO(hwc_device->eventControl(hwc_device, 0, HWC_EVENT_VSYNC, 0));
+         HWC_PLUGIN_EXPECT_ZERO(hwc_device->blank(hwc_device, 0, 1));
++        // Enter non-interactive state after turning off the screen.
++        if (pwr_device) {
++            pwr_device->setInteractive(pwr_device, false);
++        }
+     }
+     else {
++        // Enter interactive state prior to turning on the screen.
++        if (pwr_device) {
++            pwr_device->setInteractive(pwr_device, true);
++        }
+         HWC_PLUGIN_EXPECT_ZERO(hwc_device->blank(hwc_device, 0, 0));
+         HWC_PLUGIN_EXPECT_ZERO(hwc_device->eventControl(hwc_device, 0, HWC_EVENT_VSYNC, 1));
+     }
+diff --git a/hwcomposer/hwcomposer_backend_v10.h b/hwcomposer/hwcomposer_backend_v10.h
+index 1f5da46..d1e8f4b 100644
+--- a/hwcomposer/hwcomposer_backend_v10.h
++++ b/hwcomposer/hwcomposer_backend_v10.h
+@@ -51,7 +51,7 @@
+ 
+ class HwComposerBackend_v10 : public HwComposerBackend {
+ public:
+-    HwComposerBackend_v10(hw_module_t *hwc_module, hw_device_t *hw_device, void *libminisf);
++    HwComposerBackend_v10(hw_module_t *hwc_module, hw_device_t *hw_device, power_module_t *pw_device, void *libminisf);
+     virtual ~HwComposerBackend_v10();
+ 
+     virtual EGLNativeDisplayType display();
+@@ -72,6 +72,7 @@ public:
+ 
+ private:
+     hwc_composer_device_1_t *hwc_device;
++    power_module_t *pwr_device;
+     hwc_display_contents_1_t *hwc_list;
+     hwc_display_contents_1_t **hwc_mList;
+     int hwc_numDisplays;
+diff --git a/hwcomposer/hwcomposer_backend_v11.cpp b/hwcomposer/hwcomposer_backend_v11.cpp
+index 23e51ab..73f7a93 100644
+--- a/hwcomposer/hwcomposer_backend_v11.cpp
++++ b/hwcomposer/hwcomposer_backend_v11.cpp
+@@ -178,9 +178,10 @@ void HWComposer::present(HWComposerNativeWindowBuffer *buffer)
+     }
+ }
+ 
+-HwComposerBackend_v11::HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, void *libminisf, int num_displays)
++HwComposerBackend_v11::HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, power_module_t *pw_device, void *libminisf, int num_displays)
+     : HwComposerBackend(hwc_module, libminisf)
+     , hwc_device((hwc_composer_device_1_t *)hw_device)
++    , pwr_device(pw_device)
+     , hwc_list(NULL)
+     , hwc_mList(NULL)
+     , num_displays(num_displays)
+@@ -359,16 +360,33 @@ HwComposerBackend_v11::sleepDisplay(bool sleep)
+ 
  #ifdef HWC_DEVICE_API_VERSION_1_4
          if (hwc_version == HWC_DEVICE_API_VERSION_1_4) {
 -            HWC_PLUGIN_EXPECT_ZERO(hwc_device->setPowerMode(hwc_device, 0, HWC_POWER_MODE_OFF));
@@ -164,17 +262,17 @@ index 23e51ab..8f158cd 100644
          if (hwc_version == HWC_DEVICE_API_VERSION_1_4) {
              HWC_PLUGIN_EXPECT_ZERO(hwc_device->setPowerMode(hwc_device, 0, HWC_POWER_MODE_NORMAL));
 diff --git a/hwcomposer/hwcomposer_backend_v11.h b/hwcomposer/hwcomposer_backend_v11.h
-index 838557f..240033c 100644
+index 838557f..edee684 100644
 --- a/hwcomposer/hwcomposer_backend_v11.h
 +++ b/hwcomposer/hwcomposer_backend_v11.h
-@@ -56,13 +56,18 @@ class QWindow;
-
+@@ -56,13 +56,17 @@ class QWindow;
+ 
  class HwComposerBackend_v11 : public QObject, public HwComposerBackend {
  public:
 -    HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, void *libminisf, int num_displays);
 +    HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, power_module_t *pw_device, void *libminisf, int num_displays);
      virtual ~HwComposerBackend_v11();
-
+ 
      virtual EGLNativeDisplayType display();
      virtual EGLNativeWindowType createWindow(int width, int height);
      virtual void destroyWindow(EGLNativeWindowType window);
@@ -183,11 +281,10 @@ index 838557f..240033c 100644
 +    {
 +        return true;
 +    };
-+    virtual void ambientModeEnabled(bool enable) Q_DECL_OVERRIDE;
      virtual void sleepDisplay(bool sleep);
      virtual float refreshRate();
      virtual bool getScreenSizes(int *width, int *height, float *physical_width, float *physical_height);
-@@ -76,11 +81,13 @@ public:
+@@ -76,6 +80,7 @@ public:
  private:
      int getSingleAttribute(uint32_t attribute);
      hwc_composer_device_1_t *hwc_device;
@@ -195,26 +292,89 @@ index 838557f..240033c 100644
      hwc_display_contents_1_t *hwc_list;
      hwc_display_contents_1_t **hwc_mList;
      uint32_t hwc_version;
-     int num_displays;
-
-+    bool m_ambientMode;
-     bool m_displayOff;
-     QBasicTimer m_deliverUpdateTimeout;
-     QBasicTimer m_vsyncTimeout;
+diff --git a/hwcomposer/hwcomposer_backend_v20.cpp b/hwcomposer/hwcomposer_backend_v20.cpp
+index dc1d4ff..5e4d06e 100644
+--- a/hwcomposer/hwcomposer_backend_v20.cpp
++++ b/hwcomposer/hwcomposer_backend_v20.cpp
+@@ -211,9 +211,10 @@ void HWC2Window::present(HWComposerNativeWindowBuffer *buffer)
+ 
+ int HwComposerBackend_v20::composerSequenceId = 0;
+ 
+-HwComposerBackend_v20::HwComposerBackend_v20(hw_module_t *hwc_module, void *libminisf)
++HwComposerBackend_v20::HwComposerBackend_v20(hw_module_t *hwc_module, power_module_t *pw_device, void *libminisf)
+     : HwComposerBackend(hwc_module, libminisf)
+     , hwc2_device(NULL)
++    , pwr_device(pw_device)
+     , hwc2_primary_display(NULL)
+     , hwc2_primary_layer(NULL)
+     , m_displayOff(true)
+@@ -324,8 +325,20 @@ HwComposerBackend_v20::sleepDisplay(bool sleep)
+         m_vsyncTimeout.stop();
+         hwc2_compat_display_set_vsync_enabled(hwc2_primary_display, HWC2_VSYNC_DISABLE);
+ 
+-        hwc2_compat_display_set_power_mode(hwc2_primary_display, HWC2_POWER_MODE_OFF);
++        if (m_ambientMode) {
++            hwc2_compat_display_set_power_mode(hwc2_primary_display, HWC2_POWER_MODE_DOZE_SUSPEND);
++        } else {
++            hwc2_compat_display_set_power_mode(hwc2_primary_display, HWC2_POWER_MODE_OFF);
++        }
++        // Enter non-interactive state after turning off the screen.
++        if (pwr_device) {
++            pwr_device->setInteractive(pwr_device, false);
++        }
+     } else {
++        // Enter interactive state prior to turning on the screen.
++        if (pwr_device) {
++            pwr_device->setInteractive(pwr_device, true);
++        }
+         hwc2_compat_display_set_power_mode(hwc2_primary_display, HWC2_POWER_MODE_ON);
+ 
+         // If we have pending updates, make sure those start happening now..
+diff --git a/hwcomposer/hwcomposer_backend_v20.h b/hwcomposer/hwcomposer_backend_v20.h
+index 0c79cb0..e2170bd 100644
+--- a/hwcomposer/hwcomposer_backend_v20.h
++++ b/hwcomposer/hwcomposer_backend_v20.h
+@@ -57,13 +57,17 @@ class QWindow;
+ 
+ class HwComposerBackend_v20 : public QObject, public HwComposerBackend {
+ public:
+-    HwComposerBackend_v20(hw_module_t *hwc_module, void *libminisf);
++    HwComposerBackend_v20(hw_module_t *hwc_module, power_module_t *pw_device, void *libminisf);
+     virtual ~HwComposerBackend_v20();
+ 
+     virtual EGLNativeDisplayType display();
+     virtual EGLNativeWindowType createWindow(int width, int height);
+     virtual void destroyWindow(EGLNativeWindowType window);
+     virtual void swap(EGLNativeDisplayType display, EGLSurface surface);
++    virtual bool ambientModeSupport() Q_DECL_OVERRIDE
++    {
++        return true;
++    };
+     virtual void sleepDisplay(bool sleep);
+     virtual float refreshRate();
+     virtual bool getScreenSizes(int *width, int *height, float *physical_width, float *physical_height);
+@@ -81,6 +85,7 @@ public:
+ 
+ private:
+     hwc2_compat_device_t* hwc2_device;
++    power_module_t *pwr_device;
+     hwc2_compat_display_t* hwc2_primary_display;
+     hwc2_compat_layer_t* hwc2_primary_layer;
+ 
 diff --git a/hwcomposer/hwcomposer_context.cpp b/hwcomposer/hwcomposer_context.cpp
-index ca433da..2ea0e3c 100644
+index ca433da..7eea4b8 100644
 --- a/hwcomposer/hwcomposer_context.cpp
 +++ b/hwcomposer/hwcomposer_context.cpp
-@@ -74,6 +74,7 @@ HwComposerContext::HwComposerContext()
+@@ -73,6 +73,7 @@ static void exit_qt_gracefully(int sig)
+ HwComposerContext::HwComposerContext()
      : info(NULL)
      , backend(NULL)
-     , display_off(false)
 +    , ambientMode(false)
+     , display_off(false)
      , window_created(false)
      , fps(0)
- {
 @@ -163,7 +164,7 @@ void HwComposerContext::destroyNativeWindow(EGLNativeWindowType window)
-
+ 
  void HwComposerContext::swapToWindow(QEglFSContext *context, QPlatformSurface *surface)
  {
 -    if (display_off) {
@@ -225,7 +385,7 @@ index ca433da..2ea0e3c 100644
 @@ -173,6 +174,19 @@ void HwComposerContext::swapToWindow(QEglFSContext *context, QPlatformSurface *s
      return backend->swap(egl_display, egl_surface);
  }
-
+ 
 +bool HwComposerContext::ambientModeSupport()
 +{
 +    return backend->ambientModeSupport();
@@ -247,14 +407,14 @@ index e81f527..ee731f4 100644
 --- a/hwcomposer/hwcomposer_context.h
 +++ b/hwcomposer/hwcomposer_context.h
 @@ -86,6 +86,8 @@ public:
-
+ 
      void swapToWindow(QEglFSContext *context, QPlatformSurface *surface);
-
+ 
 +    bool ambientModeSupport();
 +    void ambientModeEnabled(bool enable);
      void sleepDisplay(bool sleep);
      qreal refreshRate() const;
-
+ 
 @@ -94,6 +96,7 @@ public:
  private:
      HwComposerScreenInfo *info;
@@ -268,7 +428,7 @@ index 81cc83d..e14bdfd 100644
 --- a/hwcomposer/qeglfsintegration.cpp
 +++ b/hwcomposer/qeglfsintegration.cpp
 @@ -210,6 +210,12 @@ void *QEglFSIntegration::nativeResourceForIntegration(const QByteArray &resource
-
+ 
      if (lowerCaseResource == "egldisplay") {
          return static_cast<QEglFSScreen *>(mScreen)->display();
 +    } else if (lowerCaseResource == "ambientsupported") {
@@ -280,5 +440,6 @@ index 81cc83d..e14bdfd 100644
      } else if (lowerCaseResource == "displayoff") {
          // Called from lipstick to turn off the display (src/homeapplication.cpp)
          mHwc->sleepDisplay(true);
---
-2.31.1
+-- 
+2.37.3
+

--- a/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
+++ b/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
@@ -16,7 +16,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 SRC_URI = "git://github.com/mer-hybris/qt5-qpa-hwcomposer-plugin;protocol=https;branch=master \
         file://0001-Add-ambient-mode-display-support.patch;striplevel=2 "
 S = "${WORKDIR}/git/hwcomposer"
-SRCREV = "e9b72254c368d82961913f1a28134f472076f3d6"
+SRCREV = "f1d9aef9693bb5ed5f586f3e7c07ac6ee756e21f"
 
 inherit qmake5 pkgconfig
 


### PR DESCRIPTION
This adds support for Always-on-Display on hwc2 devices (Android 9+).

Additionally it adds support for the use of the PowerHAL on older hwc versions.

Signed-off-by: Darrel Griët <dgriet@gmail.com>