### PR TITLE
Fix OPENSSL_LINKING_MODE in qtbase

### DIFF
--- a/recipes-qt/qt5/qtbase_git.bbappend
+++ b/recipes-qt/qt5/qtbase_git.bbappend
@@ -12,5 +12,6 @@ QT_CONFIG_FLAGS += "--no-feature-getentropy"
 
 QT_CONFIG_FLAGS += "-no-qpa-platform-guard ${@bb.utils.contains('DISTRO_FEATURES', 'ld-is-gold', '-use-gold-linker', '-no-use-gold-linker', d)}"
 PACKAGECONFIG_X11 = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'xcb xrender xinput2 glib xkb xkbcommon', 'xkbcommon', d)}"
+OPENSSL_LINKING_MODE = "-linked"
 
 DEPENDS += "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"


### PR DESCRIPTION
By default, qtbase 5 attempts to load libssl-1_1 and libcrypto-1_1 as can be seen in this function: https://github.com/qt/qtbase/blob/v5.15.4-lts-lgpl/src/network/ssl/qsslsocket_openssl_symbols.cpp#L670

The problem is that those versions are old and don't handle ssl very well.  This Javascript code was being called in response to a button press in QML, but the request failed every time.

    function getWeatherForecast(lat, lon, apikey) {
        const xhttp = new XMLHttpRequest();
        xhttp.onreadystatechange = function() {
            if (xhttp.readyState == XMLHttpRequest.DONE && xhttp.status == 200) {
                updateForecast(xhttp.responseText.toString());
            } else {
                console.log("readystate: ", xhttp.readyState);
                console.log("HTTP status: ", xhttp.status);
            }
        };
        var url = "https://asteroidos.org/CNAME";
        console.log("url: ", url);
        xhttp.open("GET", url);
        xhttp.send();
    }

See https://github.com/meta-qt5/meta-qt5/issues/437 for both a very similar report and the suggested fix that this patch incorporates.

Signed-off-by: Ed Beroset <beroset@ieee.org>