### PR TITLE
gdb: Enable LZMA support.

### DIFF
--- a/recipes-devtools/gdb/gdb_%.bbappend
+++ b/recipes-devtools/gdb/gdb_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append = " xz python readline babeltrace "


### PR DESCRIPTION
Enable some features within GDB to improve debugging. Enabling LZMA support fixes issues like:
```
warning: Cannot parse .gnu_debugdata section; LZMA support was disabled at compile time
```

Signed-off-by: Darrel Griët <dgriet@gmail.com>