### PR TITLE
Add Thread-Local Storage tests and workaround.

### DIFF
--- a/recipes-android/tls-padding/tls-padding.bb
+++ b/recipes-android/tls-padding/tls-padding.bb
@@ -1,0 +1,27 @@
+DESCRIPTION = "Reserve some TLS space."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=8e3cdbf510d6bb5771a8ecbb40cd4fa3"
+SRC_URI = "git://gitlab.com/ubports/development/core/hybris-support/tls-padding.git;protocol=https;branch=main \
+    file://tls-padding.conf"
+SRCREV = "c85ac0910effbf0197e43ba803536f2c7e289564"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+inherit pkgconfig
+
+EXTRA_OEMAKE = "KEEP_SYMBOLS=1"
+PARALLEL_MAKE = ""
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+do_install() {
+    install -m 0755 -d ${D}${bindir}
+    install -m 0755 ${S}/ld_preload_tls_padding.sh ${D}${bindir}
+    install -d ${D}${libdir}/
+    install -m 0644 ${S}/libtls-padding.so ${D}${libdir}/
+    install -d ${D}${sysconfdir}/ld.so.conf.d/
+    install -m 0644 ${WORKDIR}/tls-padding.conf ${D}${sysconfdir}/ld.so.conf.d/
+}
+
+FILES:${PN} += "${libdir}/libtls-padding.so"
+FILES:${PN}-dev = "${includedir}"

--- a/recipes-android/tls-padding/tls-padding/tls-padding.conf
+++ b/recipes-android/tls-padding/tls-padding/tls-padding.conf
@@ -1,0 +1,1 @@
+libtls-padding.so

--- a/recipes-test/tls-regression-test/tls-regression-test.bb
+++ b/recipes-test/tls-regression-test/tls-regression-test.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "TLS regression test to check for Bionic and libc TLS area conflicts."
+HOMEPAGE = "https://paste.pound-python.org/show/RXOUuQQKmuQ0bYSJHACy/"
+LICENSE = "CLOSED"
+PR = "r0"
+SRC_URI = "https://paste.pound-python.org/raw/RXOUuQQKmuQ0bYSJHACy/;downloadfilename=tls-regression-test.c"
+SRC_URI[md5sum] = "a988a6a447c8ec198d24f0125c8393e9"
+SRC_URI[sha256sum] = "7ce33978b7c773c5e6c942e7d716b95cbbc22b37a4566fc52e6441cfbc9a46b7"
+S = "${WORKDIR}"
+PACKAGE_DEBUG_SPLIT_STYLE = "debug-without-src"
+
+DEPENDS = "libhybris"
+
+do_compile() {
+    ${CC} ${CFLAGS} ${LDFLAGS} ${S}/tls-regression-test.c -o ${S}/tls-regression-test -lEGL -lGLESv2
+}
+
+do_install() {
+    install -m 0755 -d ${D}${bindir}
+    install -m 0755 ${S}/tls-regression-test ${D}${bindir}
+}
+


### PR DESCRIPTION
We've seen multiple instances where stranges crashes would occur. The cause could be related to thread local storage conflicts between Android libraries (via libhybris) and LibC. This adds a recipe to check for those conflicts and a workaround library to pad the TLS space.

Signed-off-by: Darrel Griët <dgriet@gmail.com>