### PR TITLE
Add recipes for generic patched Android libhybris libraries.

### DIFF
--- a/recipes-android/android/android.inc
+++ b/recipes-android/android/android.inc
@@ -1,0 +1,33 @@
+SUMMARY = "Installs precompiled patched Android libraries for use with libhybris"
+
+inherit gettext
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+INHIBIT_PACKAGE_STRIP = "1"
+INSANE_SKIP:${PN} = "already-stripped"
+S = "${WORKDIR}"
+B = "${S}"
+
+PROVIDES += "virtual/android-system-image"
+PROVIDES += "virtual/android-headers"
+
+do_install() {
+    install -d ${D}/usr/
+    cp -r usr/* ${D}/usr/
+
+    install -d ${D}${includedir}/android
+    cp -r include/* ${D}${includedir}/android/
+
+    install -d ${D}${libdir}/pkgconfig
+    install -m 0644 ${D}${includedir}/android/android-headers.pc ${D}${libdir}/pkgconfig
+    rm ${D}${includedir}/android/android-headers.pc
+}
+
+# FIXME: QA Issue: Architecture did not match (40 to 164) on /work/dory-oe-linux-gnueabi/android/lollipop-r0/packages-split/android-system/system/vendor/firmware/adsp.b00 [arch]
+do_package_qa() {
+}
+
+PACKAGES =+ "android-system android-headers"
+FILES:android-system = "/usr"
+FILES:android-headers = "${libdir}/pkgconfig ${includedir}/android"
+EXCLUDE_FROM_SHLIBS = "1"

--- a/recipes-android/android/android_msm8909-pie.bb
+++ b/recipes-android/android/android_msm8909-pie.bb
@@ -1,0 +1,9 @@
+SUMMARY = "Downloads the Snapdragon Wear 2100 /usr/libexec/hal-droid and /usr/include/android folders and installs them for libhybris"
+LICENSE = "CLOSED"
+
+SRC_URI = "https://dl.dropboxusercontent.com/s/xhtzxu3i1rj550x/hybris-p-msm8909.tar.gz"
+SRC_URI[md5sum] = "498f109103d8442ad9c0308da9109cc1"
+SRC_URI[sha256sum] = "a13c40696d905076f71a5edc9810c40e628428c6eb4d4bd46d66b9c0c705db4d"
+PV = "msm8909+pie"
+
+require android.inc

--- a/recipes-android/android/android_msm8909w-pie.bb
+++ b/recipes-android/android/android_msm8909w-pie.bb
@@ -1,0 +1,9 @@
+SUMMARY = "Downloads the Snapdragon Wear 3100 /usr/libexec/hal-droid and /usr/include/android folders and installs them for libhybris"
+LICENSE = "CLOSED"
+
+SRC_URI = "https://dl.dropboxusercontent.com/s/2btck4hlowhronv/hybris-p-msm8909w.tar.gz"
+SRC_URI[md5sum] = "cc084ae844473e074f06391033a08c46"
+SRC_URI[sha256sum] = "d7d91700007795aedcdf4fffa418552edf2b3fd41a0223367401906f4f4dfed3"
+PV = "msm8909w+pie"
+
+require android.inc


### PR DESCRIPTION
Add a generic `android` base recipe that other ports can inherit to install the bare minimum Android patched libhybris libraries. Also provide two recipes one for Wear 2100 watches and one for Wear 3100 watches, both target an Android 9 base (system and vendor partition).

A watch layer can select either of the recipes by adding a PREFERRED_VERSION_android, like so: PREFERRED_VERSION_android = "msm8909w+pie"

Some references on how these are built:
- https://github.com/MagneFire/android_manifest/tree/hybris-msm8909-9.0
- https://github.com/MagneFire/android_device_asteroid_g8909w
- https://github.com/MagneFire/android_device_asteroid_g8909
- It's loosely based upon: https://docs.sailfishos.org/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_9_Build_and_Flash/