### PR TITLE
Add packages for NFC support.

### DIFF
--- a/recipes-nemomobile/libdbusaccess/libdbusaccess_git.bb
+++ b/recipes-nemomobile/libdbusaccess/libdbusaccess_git.bb
@@ -1,0 +1,22 @@
+SUMMARY = "SailfishOS D-Bus access control library"
+HOMEPAGE = "https://github.com/sailfishos/libdbusaccess"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3c402472f78e29b699385e25fd89b4a9"
+
+SRC_URI = "git://github.com/sailfishos/libdbusaccess.git;protocol=https;branch=master"
+SRCREV = "a311a847c4b6c5bd154858dec63bd5103d11cf63"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+DEPENDS += "glib-2.0 libglibutil glib-2.0-native systemd libgbinder bison-native"
+
+EXTRA_OEMAKE = "KEEP_SYMBOLS=1"
+
+do_install() {
+	oe_runmake install DESTDIR=${D}
+	oe_runmake install-dev DESTDIR=${D}
+}
+
+inherit pkgconfig
+inherit systemd

--- a/recipes-nemomobile/libnci/libncicore/0001-Makefile-Allow-for-CC-to-be-overridden.patch
+++ b/recipes-nemomobile/libnci/libncicore/0001-Makefile-Allow-for-CC-to-be-overridden.patch
@@ -1,0 +1,40 @@
+From 2401dbb5b81cf64d39d6ae630aec61ed595fdbac Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Sun, 20 Nov 2022 18:23:10 +0100
+Subject: [PATCH] Makefile: Allow for CC to be overridden.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ Makefile             | 2 +-
+ unit/common/Makefile | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 6632fab..6c858c9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -84,7 +84,7 @@ COVERAGE_BUILD_DIR = $(BUILD_DIR)/coverage
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ WARNINGS = -Wall -Wstrict-aliasing -Wunused-result
+ INCLUDES = -I$(INCLUDE_DIR)
+diff --git a/unit/common/Makefile b/unit/common/Makefile
+index 8e55c63..99d8784 100644
+--- a/unit/common/Makefile
++++ b/unit/common/Makefile
+@@ -41,7 +41,7 @@ COVERAGE_BUILD_DIR = $(BUILD_DIR)/coverage
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ WARNINGS += -Wall
+ INCLUDES += -I$(COMMON_DIR) -I$(LIB_DIR)/src -I$(LIB_DIR)/include

--- a/recipes-nemomobile/libnci/libncicore_git.bb
+++ b/recipes-nemomobile/libnci/libncicore_git.bb
@@ -1,0 +1,23 @@
+SUMMARY = "mer-hybris libncicore"
+HOMEPAGE = "https://github.com/mer-hybris/libncicore"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=8dca037da60041e7ec2349c7aedb18c1"
+
+SRC_URI = "git://github.com/mer-hybris/libncicore.git;protocol=https;branch=master \
+           file://0001-Makefile-Allow-for-CC-to-be-overridden.patch \
+           "
+SRCREV = "7c4e1a8a743bbd713e684a824442f663cadb7a83"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+DEPENDS += "glib-2.0 libglibutil glib-2.0-native"
+
+EXTRA_OEMAKE = "KEEP_SYMBOLS=1"
+
+do_install() {
+	oe_runmake install DESTDIR=${D}
+	oe_runmake install-dev DESTDIR=${D}
+}
+
+inherit pkgconfig

--- a/recipes-nemomobile/libnci/libnciplugin/0001-Makefile-Allow-for-CC-to-be-overridden.patch
+++ b/recipes-nemomobile/libnci/libnciplugin/0001-Makefile-Allow-for-CC-to-be-overridden.patch
@@ -1,0 +1,26 @@
+From 42c61e04e8c12e18ef12bf0e2c380bf7c332a71d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Sun, 20 Nov 2022 18:29:17 +0100
+Subject: [PATCH] Makefile: Allow for CC to be overridden.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 4277a11..76a8e87 100644
+--- a/Makefile
++++ b/Makefile
+@@ -62,7 +62,7 @@ COVERAGE_BUILD_DIR = $(BUILD_DIR)/coverage
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ WARNINGS = -Wall -Wstrict-aliasing -Wunused-result
+ INCLUDES = -I$(INCLUDE_DIR)

--- a/recipes-nemomobile/libnci/libnciplugin_git.bb
+++ b/recipes-nemomobile/libnci/libnciplugin_git.bb
@@ -1,0 +1,24 @@
+SUMMARY = "mer-hybris libnciplugin"
+HOMEPAGE = "https://github.com/mer-hybris/libnciplugin"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c049b5654a2ea5d8d3b45c4416abe4ae"
+
+SRC_URI = "git://github.com/mer-hybris/libnciplugin.git;protocol=https;branch=master \
+           file://0001-Makefile-Allow-for-CC-to-be-overridden.patch \
+           "
+SRCREV = "3b844682112733be1b1d6d2bc745dab40f03b152"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+B = "${S}"
+
+DEPENDS = "libgbinder glib-2.0 libglibutil nfcd libncicore"
+
+EXTRA_OEMAKE = "KEEP_SYMBOLS=1"
+
+do_install() {
+	oe_runmake install DESTDIR=${D}
+	oe_runmake install-dev DESTDIR=${D}
+}
+
+inherit pkgconfig

--- a/recipes-nemomobile/mce/libmce-glib_git.bb
+++ b/recipes-nemomobile/mce/libmce-glib_git.bb
@@ -1,0 +1,21 @@
+SUMMARY = "Mce glib bindings."
+HOMEPAGE = "https://github.com/sailfishos/libmce-glib"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e8bb33b697424420fc8b5633344bdf0f"
+
+SRC_URI = "git://github.com/sailfishos/libmce-glib.git;protocol=https;branch=master"
+SRCREV = "9a14618c13b2b8267af40d04633543689d1caab8"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+DEPENDS += "glib-2.0 glib-2.0-native libglibutil mcedevel"
+
+EXTRA_OEMAKE = "KEEP_SYMBOLS=1"
+
+do_install() {
+	oe_runmake install DESTDIR=${D}
+	oe_runmake install-dev DESTDIR=${D}
+}
+
+inherit pkgconfig

--- a/recipes-nemomobile/nfcd/nfcd-binder-plugin/0001-Makefile-Allow-for-CC-to-be-overridden.patch
+++ b/recipes-nemomobile/nfcd/nfcd-binder-plugin/0001-Makefile-Allow-for-CC-to-be-overridden.patch
@@ -1,0 +1,26 @@
+From deac66571ae4a456dfef27bfa363dfd2d3a85b82 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Sun, 20 Nov 2022 18:33:20 +0100
+Subject: [PATCH] Makefile: Allow for CC to be overridden.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 3fc25f2..f819b5b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -45,7 +45,7 @@ RELEASE_BUILD_DIR = $(BUILD_DIR)/release
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ WARNINGS = -Wall
+ BASE_FLAGS = -fPIC -fvisibility=hidden

--- a/recipes-nemomobile/nfcd/nfcd-binder-plugin_git.bb
+++ b/recipes-nemomobile/nfcd/nfcd-binder-plugin_git.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Nemomobile's NFC daemon's hwbinder plugin"
+HOMEPAGE = "https://github.com/mer-hybris/nfcd-binder-plugin"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://src/plugin.h;beginline=1;endline=31;md5=ba484c1af8c917210c60e63b7b499327"
+
+SRC_URI = "git://github.com/mer-hybris/nfcd-binder-plugin.git;protocol=https;branch=master \
+           file://0001-Makefile-Allow-for-CC-to-be-overridden.patch \
+           "
+SRCREV = "4e9210573118eee93359bdd2653488de4a36649f"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+B = "${S}"
+
+DEPENDS = "libgbinder glib-2.0 libglibutil nfcd libncicore libnciplugin"
+
+do_install() {
+	oe_runmake install DESTDIR=${D}
+}
+
+inherit pkgconfig
+
+FILES:${PN} += "${libdir}/nfcd/plugins/binder.so"

--- a/recipes-nemomobile/nfcd/nfcd-mce-plugin_git.bb
+++ b/recipes-nemomobile/nfcd/nfcd-mce-plugin_git.bb
@@ -1,0 +1,20 @@
+SUMMARY = "nfcd plugin for mce-based device state tracking.."
+HOMEPAGE = "https://github.com/mer-hybris/nfcd-mce-plugin.git"
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=bfbedcf6cc318e76a7b5ecb7d72ecaa0"
+
+SRC_URI = "git://github.com/mer-hybris/nfcd-mce-plugin.git;protocol=https;branch=master"
+SRCREV = "87e762e063f9c645762ee7e4bb6f9d1df80a052b"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+DEPENDS = "libnciplugin libmce-glib"
+
+do_install() {
+    oe_runmake install DESTDIR=${D}
+}
+
+inherit pkgconfig
+
+FILES:${PN} += "${libdir}/nfcd/plugins/mce.so"

--- a/recipes-nemomobile/nfcd/nfcd/0001-Makefile-Allow-for-CC-to-be-overridden.patch
+++ b/recipes-nemomobile/nfcd/nfcd/0001-Makefile-Allow-for-CC-to-be-overridden.patch
@@ -1,0 +1,138 @@
+From 60241170a99ca9780db0fe1567da51cd9ca798f0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Sun, 20 Nov 2022 17:55:53 +0100
+Subject: [PATCH] Makefile: Allow for CC to be overridden.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ core/Makefile                | 2 +-
+ plugins/Makefile             | 2 +-
+ src/Makefile                 | 2 +-
+ test/nfcdep-client/Makefile  | 2 +-
+ test/nfcdep-service/Makefile | 2 +-
+ tools/iso-dep/Makefile       | 2 +-
+ tools/ndef-read/Makefile     | 2 +-
+ tools/ndef-write/Makefile    | 2 +-
+ unit/common/Makefile         | 2 +-
+ 9 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/core/Makefile b/core/Makefile
+index f815813..c55eac2 100644
+--- a/core/Makefile
++++ b/core/Makefile
+@@ -93,7 +93,7 @@ PCVERSION = $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_RELEASE)
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ WARNINGS = -Wall -Wstrict-aliasing -Wunused-result
+ INCLUDES = -I$(INCLUDE_DIR)
+diff --git a/plugins/Makefile b/plugins/Makefile
+index 7fc9ace..5b8570a 100644
+--- a/plugins/Makefile
++++ b/plugins/Makefile
+@@ -256,7 +256,7 @@ $(COVERAGE_DBUS_HANDLERS_BUILD_DIR):
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ WARNINGS = -Wall -Wstrict-aliasing -Wunused-result
+ INCLUDES = -I. -I../core/include -I$(GEN_DIR)
+diff --git a/src/Makefile b/src/Makefile
+index a5264e7..bd8b630 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -70,7 +70,7 @@ NFC_PLUGINS_RELEASE_LIB = $(NFC_PLUGINS_BUILD_DIR)/release/$(NFC_PLUGINS_LIB)
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ DEBUG_FLAGS = -g
+ RELEASE_FLAGS =
+diff --git a/test/nfcdep-client/Makefile b/test/nfcdep-client/Makefile
+index 998472e..c29905f 100644
+--- a/test/nfcdep-client/Makefile
++++ b/test/nfcdep-client/Makefile
+@@ -43,7 +43,7 @@ RELEASE_BUILD_DIR = $(BUILD_DIR)/release
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ DEBUG_FLAGS = -g
+ RELEASE_FLAGS =
+diff --git a/test/nfcdep-service/Makefile b/test/nfcdep-service/Makefile
+index 33eb950..9021560 100644
+--- a/test/nfcdep-service/Makefile
++++ b/test/nfcdep-service/Makefile
+@@ -42,7 +42,7 @@ RELEASE_BUILD_DIR = $(BUILD_DIR)/release
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ DEBUG_FLAGS = -g
+ RELEASE_FLAGS =
+diff --git a/tools/iso-dep/Makefile b/tools/iso-dep/Makefile
+index 51f4b2e..ea20295 100644
+--- a/tools/iso-dep/Makefile
++++ b/tools/iso-dep/Makefile
+@@ -44,7 +44,7 @@ RELEASE_BUILD_DIR = $(BUILD_DIR)/release
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ DEBUG_FLAGS = -g
+ RELEASE_FLAGS =
+diff --git a/tools/ndef-read/Makefile b/tools/ndef-read/Makefile
+index 51bd9c7..1f01fd2 100644
+--- a/tools/ndef-read/Makefile
++++ b/tools/ndef-read/Makefile
+@@ -55,7 +55,7 @@ NFC_CORE_RELEASE_LIB = $(NFC_CORE_BUILD_DIR)/release/$(NFC_CORE_LIB)
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ DEBUG_FLAGS = -g
+ RELEASE_FLAGS =
+diff --git a/tools/ndef-write/Makefile b/tools/ndef-write/Makefile
+index 3d47471..6000d81 100644
+--- a/tools/ndef-write/Makefile
++++ b/tools/ndef-write/Makefile
+@@ -56,7 +56,7 @@ NFC_CORE_RELEASE_LIB = $(NFC_CORE_BUILD_DIR)/release/$(NFC_CORE_LIB)
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ DEBUG_FLAGS = -g
+ RELEASE_FLAGS =
+diff --git a/unit/common/Makefile b/unit/common/Makefile
+index 96f920c..512d081 100644
+--- a/unit/common/Makefile
++++ b/unit/common/Makefile
+@@ -59,7 +59,7 @@ endif
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ WARNINGS += -Wall
+ INCLUDES += -I$(COMMON_DIR) -I$(CORE_DIR)/src -I$(CORE_DIR)/include

--- a/recipes-nemomobile/nfcd/nfcd/0002-Makefile-Allow-for-INSTALL_SYSTEMD_DIR-to-be-overrid.patch
+++ b/recipes-nemomobile/nfcd/nfcd/0002-Makefile-Allow-for-INSTALL_SYSTEMD_DIR-to-be-overrid.patch
@@ -1,0 +1,26 @@
+From ef9a6b7b102b2e83757ff7cfca4c17f1f336557b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Sun, 20 Nov 2022 18:44:31 +0100
+Subject: [PATCH] Makefile: Allow for INSTALL_SYSTEMD_DIR to be overridden.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ src/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Makefile b/src/Makefile
+index bd8b630..ee4f3d0 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -204,7 +204,7 @@ INSTALL = install
+ INSTALL_DIRS = $(INSTALL) -d
+ 
+ INSTALL_SBIN_DIR = $(DESTDIR)/usr/sbin
+-INSTALL_SYSTEMD_DIR = $(DESTDIR)$(ABS_UNITDIR)
++INSTALL_SYSTEMD_DIR ?= $(DESTDIR)$(ABS_UNITDIR)
+ 
+ install: $(RELEASE_EXE) $(INSTALL_SBIN_DIR) $(INSTALL_SYSTEMD_DIR)
+ 	$(INSTALL) -m 644 nfcd.service "$(INSTALL_SYSTEMD_DIR)"

--- a/recipes-nemomobile/nfcd/nfcd_git.bb
+++ b/recipes-nemomobile/nfcd/nfcd_git.bb
@@ -1,0 +1,31 @@
+SUMMARY = "SailfishOS NFC daemon"
+HOMEPAGE = "https://github.com/sailfishos/nfcd"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=5b3f54b2e4d9f7704287bad532091824"
+
+SRC_URI = "git://github.com/sailfishos/nfcd.git;protocol=https;branch=master \
+           file://0001-Makefile-Allow-for-CC-to-be-overridden.patch \
+           file://0002-Makefile-Allow-for-INSTALL_SYSTEMD_DIR-to-be-overrid.patch \
+           "
+SRCREV = "0cdf85c5373ea94877af64e20a2b05a80074386a"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE = "KEEP_SYMBOLS=1 INSTALL_SYSTEMD_DIR=${D}${systemd_unitdir}/system/"
+
+DEPENDS += "glib-2.0 libglibutil glib-2.0-native systemd libgbinder libdbusaccess file"
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "nfcd.service"
+
+do_compile:append() {
+	oe_runmake release
+}
+
+do_install() {
+	oe_runmake install DESTDIR=${D}
+}
+
+inherit pkgconfig
+inherit systemd


### PR DESCRIPTION
This PR adds the packages to support NFC. It has been testen on `catfish` and `beluga`.
It does not work on `catfish` because of https://github.com/mer-hybris/libncicore/issues/21 (A ST21NFCD which is a  NCI 2.0 chip).
It appears to work fine on `beluga`.

The packages are not installed by default as no app within AsteroidOS would have a direct benefit from it, we could reconsider this in the future of course.