### PR TITLE
Add swclock-offset recipe.

### DIFF
--- a/recipes-android/swclock-offset/swclock-offset/swclock-offset.service
+++ b/recipes-android/swclock-offset/swclock-offset/swclock-offset.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Synchronize time from a non-writable real-time clock (RTC) using a cached file.
+After=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=Yes
+TimeoutSec=0
+ExecStart=-/usr/sbin/swclock-offset-boot
+ExecStop=/usr/sbin/swclock-offset-shutdown
+
+[Install]
+WantedBy=basic.target

--- a/recipes-android/swclock-offset/swclock-offset_git.bb
+++ b/recipes-android/swclock-offset/swclock-offset_git.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Synchronize time from a non-writable real-time clock (RTC) using a cached file."
+HOMEPAGE = "https://gitlab.com/postmarketOS/swclock-offset"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1b72c0c4f0ef6806f2bc255ef3ca61c1"
+
+SRC_URI = "git://gitlab.com/postmarketOS/swclock-offset.git;protocol=https;branch=master \
+    file://swclock-offset.service"
+SRCREV = "a7888660b23d722b26e86c1b31a909bd8ad84bd2"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "swclock-offset.service"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    oe_runmake install DESTDIR=${D} PREFIX=${prefix}
+
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/swclock-offset.service ${D}${systemd_unitdir}/system/
+}
+
+inherit systemd


### PR DESCRIPTION
This PR adds the recipe for swclock-offset (https://gitlab.com/postmarketOS/swclock-offset).
It's purpose is to restore the system time from a non-writeable RTC by using a cached file. Which appears to be an issue on some Qualcomm based watches.

I've also made a PR upstream, but we can use this until that one is merged:
https://gitlab.com/postmarketOS/swclock-offset/-/merge_requests/3

Thanks for @dodoradio for his initial work on this!