### PR TITLE
geoclue-provider-hybris: hal: Handle not being able to set the SUPL server.

### DIFF
--- a/recipes-nemomobile/geoclue-providers/files/0002-hal-Handle-not-being-able-to-set-the-SUPL-server.patch
+++ b/recipes-nemomobile/geoclue-providers/files/0002-hal-Handle-not-being-able-to-set-the-SUPL-server.patch
@@ -1,0 +1,31 @@
+From a5b3833cceb9094a0e1d7a667dec05a029ebee4d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Tue, 13 Dec 2022 23:20:00 +0100
+Subject: [PATCH] hal: Handle not being able to set the SUPL server.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+https://github.com/mer-hybris/geoclue-providers-hybris/commit/e982cf94047993e5868d44307f4a38f1b89500ea added support for overriding/setting the SUPL server.
+This could however lead to a crash when AGPS isn't actually available. Handle this by returning an error instead of crashing.
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ hal/hallocationbackend.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/hal/hallocationbackend.cpp b/hal/hallocationbackend.cpp
+index 50a9662..14c5546 100644
+--- a/hal/hallocationbackend.cpp
++++ b/hal/hallocationbackend.cpp
+@@ -681,6 +681,7 @@ bool HalLocationBackend::aGnssDataConnOpen(const QByteArray &apn, const QString
+ 
+ int HalLocationBackend::aGnssSetServer(HybrisAGnssType type, const char* hostname, int port)
+ {
++    if (!m_agps) return 0;
+     return m_agps->set_server(type, hostname, port);
+ }
+ 
+-- 
+2.39.0
+

--- a/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris.inc
+++ b/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris.inc
@@ -4,7 +4,8 @@ LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/mer-hybris/geoclue-providers-hybris.git;protocol=https;branch=master \
-    file://0001-pri-Fix-host-contamination-path-issue.patch"
+    file://0001-pri-Fix-host-contamination-path-issue.patch \
+    file://0002-hal-Handle-not-being-able-to-set-the-SUPL-server.patch"
 SRCREV = "0.2.35"
 PR = "r1"
 PV = "+git${SRCPV}"


### PR DESCRIPTION
https://github.com/mer-hybris/geoclue-providers-hybris/commit/e982cf94047993e5868d44307f4a38f1b89500ea added support for overriding/setting the SUPL server. This could however lead to a crash when AGPS isn't actually available. Handle this by returning an error instead of crashing.

Signed-off-by: Darrel Griët <dgriet@gmail.com>

This patch will be dropped when the upstream PR is merged: https://github.com/mer-hybris/geoclue-providers-hybris/pull/44