### PR TITLE
Enable proper qmake, Qt Linguist, moc/uic/rcc, and CMake support in SDKs

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -2,6 +2,9 @@ inherit core-image
 inherit extrausers
 LICENSE = "GPL-2.0-only"
 
+# Inherit this to be able to produce OE SDKs that are fully capable of building Qt5 code
+inherit populate_sdk_qt5
+
 IMAGE_FEATURES += "package-management debug-tweaks"
 
 IMAGE_INSTALL += " \

--- a/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bbappend
+++ b/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bbappend
@@ -1,3 +1,13 @@
+# - Add nativesdk-cmake to enable CMake support in SDKs.
+#   Newer Qt projects use CMake instead of qmake.
+# - Add nativesdk-qtdeclarative-tools for QML content.
+# - Add nativesdk-qttools-tools to allow for including
+#   tools like moc and uic in the SDK.
+# - Add nativesdk-qttools-dev as well, otherwise the CMake
+#   Qt5LinguistTools scripts are not included in an SDK.
 RDEPENDS:${PN} += " \
+    nativesdk-cmake \
     nativesdk-qtdeclarative-tools \
+    nativesdk-qttools-tools \
+    nativesdk-qttools-dev \
 "


### PR DESCRIPTION
This allows for building asteroid-btsyncd, asteroid-launcher etc. with SDKs generated by Yocto via calls like:

    bitbake -c populate_sdk asteroid-image