### PR TITLE
Add cli11 to SDK for building lcd_tools

### DIFF
--- a/recipes-qt/packagegroups/packagegroup-qt5-toolchain-target.bbappend
+++ b/recipes-qt/packagegroups/packagegroup-qt5-toolchain-target.bbappend
@@ -11,6 +11,7 @@ RDEPENDS:${PN}:remove = "qtcharts-mkspecs"
 
 RDEPENDS:${PN} += "extra-cmake-modules-dev"
 RDEPENDS:${PN} += "mcedevel-dev"
+RDEPENDS:${PN} += "cli11-dev"
 
 RDEPENDS:${PN} += "qtvirtualkeyboard-dev"
 RDEPENDS:${PN} += "qtvirtualkeyboard-plugins"


### PR DESCRIPTION
The previous version of SDK did not contain the CLI11 header-only library necessary to build lcd-tools

Signed-off-by: Ed Beroset <beroset@ieee.org>