### PR TITLE
Update package archs

### DIFF
--- a/conf/distro/asteroid.conf
+++ b/conf/distro/asteroid.conf
@@ -38,6 +38,6 @@ FILESYSTEM_PERMS_TABLES = "files/fs-perms.txt files/asteroidos-fs-perms.txt"
 
 PACKAGE_FEED_URIS = "https://release.asteroidos.org/nightlies/"
 PACKAGE_FEED_BASE_PATHS = "ipk"
-PACKAGE_FEED_ARCHS = "all anthias armv7vehf-neon bass core2-32 dory lenok qemux86 sparrow sprat sturgeon swift tetra wren"
+PACKAGE_FEED_ARCHS = "armv7at2hf-neon armv7vehf-neon core2-32"
 
 SKIP_META_GNOME_SANITY_CHECK = "1"


### PR DESCRIPTION
Strips PACKAGE_FEED_ARCHS to their respective architectures.

Due to a recent update, device specific packages no longer exist.  Throwing a list of errors with opkg.
This fixes the issue by stripping the arch list, and then adding in armv7at2hf-neon.