### PR TITLE
Changes to asteroid-image-dev

### DIFF
--- a/recipes-core/image/asteroid-image-dev.bb
+++ b/recipes-core/image/asteroid-image-dev.bb
@@ -1,3 +1,3 @@
 inherit asteroid-image
 DESCRIPTION = "Asteroid image for developers, contains development and debugging tools"
-EXTRA_IMAGE_FEATURES += "dbg-pkgs dev-pkgs tools-sdk tools-debug tools-testapps debug-tweaks"
+EXTRA_IMAGE_FEATURES += "tools-debug tools-testapps debug-tweaks"

--- a/recipes-core/image/asteroid-image-dev.bb
+++ b/recipes-core/image/asteroid-image-dev.bb
@@ -1,3 +1,15 @@
 inherit asteroid-image
 DESCRIPTION = "Asteroid image for developers, contains development and debugging tools"
 EXTRA_IMAGE_FEATURES += "tools-debug tools-testapps debug-tweaks"
+
+# Add:
+#
+# - Bluetooth tools to help diagnose and debug Bluetooth problems
+# - bash for a more powerful shell, which is useful for development
+# - htop for more detailed information about ongoing processes and
+#   their resource usage compared to the regular top tool
+IMAGE_INSTALL += " \
+        packagegroup-tools-bluetooth \
+        bash \
+        htop \
+"


### PR DESCRIPTION
These commits remove dbg-pkgs dev-pkgs to reduce image size, and add htop, bash, and extra Bluetooth tools, which are useful for development and debugging. To quote the first commit's message:

dbg-pkgs and dev-pkgs add ALL dbg and dev packages to the image. The
result is too large for some watches. And, in particular, adding dev
packages to the rootfs of a smartwatch is of very questionable use,
since this is usually done when development tools such as make, cmake,
gcc etc. are to be run on the target itself. This is unlikely to be
done on a smartwatch.