### PR TITLE
Add bluetooth-rfkill-event recipe.

### DIFF
--- a/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event-configs_git.bb
+++ b/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event-configs_git.bb
@@ -1,0 +1,19 @@
+DESCRIPTION = "Provides the device specific configuration files used by bluetooth-rfkill-daemon"
+PR = "r0"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+S = "${WORKDIR}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install() {
+    # Copy Bluetoth device configuration files.
+    install -d ${D}${datadir}/bluetooth-rfkill-event/
+    install -m 0644 ${WORKDIR}/*.conf ${D}${datadir}/bluetooth-rfkill-event/
+
+    # The config file is always required as it contains the instructions on how to start bluetooth-rfkill-event
+    install -d ${D}${sysconfdir}/sysconfig
+    install -m 0644 ${WORKDIR}/bluetooth-rfkill-event ${D}${sysconfdir}/sysconfig
+}
+
+FILES:${PN} += "${datadir}/bluetooth-rfkill-event/*"

--- a/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0001-Add-support-for-using-a-custom-rfkill-device.patch
+++ b/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0001-Add-support-for-using-a-custom-rfkill-device.patch
@@ -1,0 +1,76 @@
+From ed0212ced4d3cbf4c6fa220db223cda6b5634829 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Fri, 3 Feb 2023 23:01:19 +0100
+Subject: [PATCH] Add support for using a custom rfkill device.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ .../bluetooth_rfkill_event.c                  | 21 +++++++++++++++++--
+ 1 file changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/bluetooth-rfkill-event/bluetooth_rfkill_event.c b/bluetooth-rfkill-event/bluetooth_rfkill_event.c
+index bff3075..d8de7aa 100644
+--- a/bluetooth-rfkill-event/bluetooth_rfkill_event.c
++++ b/bluetooth-rfkill-event/bluetooth_rfkill_event.c
+@@ -130,6 +130,7 @@ char hciattach_options[PATH_MAX];
+ char hci_uart_default_dev[PATH_MAX] = BCM_43341_UART_DEV;
+ 
+ gboolean hci_dev_registered;
++char *rfkill_name = BCM_RFKILL_NAME;
+ char *bt_module = NULL;
+ char *config_file = DEFAULT_CONFIG_FILE;
+ GHashTable *switch_hash = NULL; /* hash index to metadata about the switch */
+@@ -1066,7 +1067,7 @@ static int rfkill_switch_add(struct rfkill_event *event)
+     }
+ 
+     /* based on chip read its config file, if any, and define the hciattach utility used to dowload the patch */
+-    if (!strncmp(BCM_RFKILL_NAME, sysname, sizeof(BCM_RFKILL_NAME))) {
++    if (!strncmp(rfkill_name, sysname, strlen(rfkill_name))) {
+ 	read_config(config_file);
+ 	snprintf(hciattach, sizeof(hciattach), patcher_impl[main_opts.patcher].name);
+ 	type = BT_PWR;
+@@ -1117,7 +1118,7 @@ int main(int argc, char **argv)
+         };
+         int c;
+ 
+-        c = getopt_long(argc, argv, ":b:c:ds", opts, NULL);
++        c = getopt_long(argc, argv, ":b:r:c:ds", opts, NULL);
+         if (c == -1)
+             break;
+ 
+@@ -1127,6 +1128,9 @@ int main(int argc, char **argv)
+                until BT rfkill switch is identified */
+             bt_module = optarg;
+             break;
++        case 'r':
++            rfkill_name = optarg;
++            break;
+         case 'c':
+             config_file = optarg;
+             break;
+@@ -1145,9 +1149,22 @@ int main(int argc, char **argv)
+ 
+     INFO("Starting bluetooth_rfkill_event");
+ 
++    if (!g_file_test(STORAGE_DIR, G_FILE_TEST_IS_DIR)) {
++        if (mkdir(STORAGE_DIR, (S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)) < 0) {
++            if (errno != EEXIST) {
++                FATAL("Error while creating the storage dir: "STORAGE_DIR);
++                return -errno;
++            }
++        }
++    }
++
+     random_default_bdaddr();
+     DEBUG("Default bdaddr: %s", default_bd_addr);
+ 
++    if (rfkill_name) {
++        INFO("Using rfkill device %s", rfkill_name);
++    }
++
+     /* If Bluetooth kernel module is specified, try to unload and
+        reload it before starting up. */
+     if (bt_module) {

--- a/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0001-Makefile-Allow-for-CC-to-be-overridden.patch
+++ b/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0001-Makefile-Allow-for-CC-to-be-overridden.patch
@@ -1,0 +1,40 @@
+From 2401dbb5b81cf64d39d6ae630aec61ed595fdbac Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Sun, 20 Nov 2022 18:23:10 +0100
+Subject: [PATCH] Makefile: Allow for CC to be overridden.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ Makefile             | 2 +-
+ unit/common/Makefile | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 6632fab..6c858c9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -84,7 +84,7 @@ COVERAGE_BUILD_DIR = $(BUILD_DIR)/coverage
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ WARNINGS = -Wall -Wstrict-aliasing -Wunused-result
+ INCLUDES = -I$(INCLUDE_DIR)
+diff --git a/unit/common/Makefile b/unit/common/Makefile
+index 8e55c63..99d8784 100644
+--- a/unit/common/Makefile
++++ b/unit/common/Makefile
+@@ -41,7 +41,7 @@ COVERAGE_BUILD_DIR = $(BUILD_DIR)/coverage
+ # Tools and flags
+ #
+ 
+-CC = $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD = $(CC)
+ WARNINGS += -Wall
+ INCLUDES += -I$(COMMON_DIR) -I$(LIB_DIR)/src -I$(LIB_DIR)/include

--- a/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0002-Store-custom-Bluetooth-address.patch
+++ b/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0002-Store-custom-Bluetooth-address.patch
@@ -1,0 +1,82 @@
+From 6ea36f7d1308ce1368a5bbacf288653c42b2a9f8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Fri, 3 Feb 2023 23:04:49 +0100
+Subject: [PATCH] Store custom Bluetooth address.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When no valid Bluetooth address is available a random one is used.
+But this new random Bluetooth MAC address is not stored resulting in a new Bluetooth address after every reboot.
+By storing the Bluetooth address we can ensure that the same Bluetooth address is used across reboots.
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ .../bluetooth_rfkill_event.c                  | 21 +++++++++++++++----
+ 1 file changed, 17 insertions(+), 4 deletions(-)
+
+diff --git a/bluetooth-rfkill-event/bluetooth_rfkill_event.c b/bluetooth-rfkill-event/bluetooth_rfkill_event.c
+index d8de7aa..f0ec621 100644
+--- a/bluetooth-rfkill-event/bluetooth_rfkill_event.c
++++ b/bluetooth-rfkill-event/bluetooth_rfkill_event.c
+@@ -44,6 +44,7 @@
+ #include <syslog.h>
+ #include <stdarg.h>
+ #include <glib.h>
++#include <sys/stat.h>
+ #include <bluetooth/bluetooth.h>
+ #include <bluetooth/hci.h>
+ #include <bluetooth/hci_lib.h>
+@@ -77,7 +78,8 @@ enum rfkill_switch_type {
+    name is defined in the kernel driver implementing rfkill interface for power */
+ #define BCM_RFKILL_NAME "bcm43xx Bluetooth\n"
+ #define BCM_43341_UART_DEV "/dev/ttyMFD0"
+-#define BD_ADD_FACTORY_FILE "/factory/bluetooth_address"
++#define STORAGE_DIR "/var/lib/bluetooth-rfkill-event/"
++#define BD_ADD_FACTORY_FILE STORAGE_DIR"bluetooth_address"
+ char factory_bd_add[18];
+ char default_bd_addr[18];
+ 
+@@ -771,6 +773,16 @@ gboolean check_bd_format(const char* bd_add)
+     return TRUE;
+ }
+ 
++void save_bd_add(void)
++{
++    FILE *fp;
++    fp = fopen(main_opts.bdaddr_file
++        ? main_opts.bdaddr_file
++        : BD_ADD_FACTORY_FILE, "w");
++    fputs(factory_bd_add, fp);
++    fclose(fp);
++}
++
+ void load_bd_add(void)
+ {
+     FILE *fp;
+@@ -791,21 +803,22 @@ void load_bd_add(void)
+         memcpy(factory_bd_add, default_bd_addr, sizeof(factory_bd_add));
+         main_opts.bd_add = factory_bd_add;
+         main_opts.set_bd = TRUE;
++        save_bd_add();
+         return;
+     }
+ 
+     ret = fscanf(fp, "%17c", factory_bd_add);
++    fclose(fp);
+ 
+     /* if factory BD address is not well formatted or not present use default one*/
+     if (!(ret == 1 && check_bd_format(factory_bd_add)))
+     {
++        WARN("Invalid Bluetooth address format %s", factory_bd_add);
+         memcpy(factory_bd_add, default_bd_addr, sizeof(factory_bd_add));
++        save_bd_add();
+     }
+     main_opts.bd_add = factory_bd_add;
+     main_opts.set_bd = TRUE;
+-
+-    fclose(fp);
+-
+ }
+ 
+ static void brcm_patchram_plus_cmdline()

--- a/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0003-Fix-loading-the-service-file.patch
+++ b/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0003-Fix-loading-the-service-file.patch
@@ -1,0 +1,25 @@
+From 88a23b15b3e6d502510a22693ddc8904b80848e7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Fri, 3 Feb 2023 23:09:49 +0100
+Subject: [PATCH] Fix loading the service file.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+For some unknown reason, the service isn't started even though a bluetooth target does start upon boot.
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ bluetooth-rfkill-event/bluetooth-rfkill-event.service | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bluetooth-rfkill-event/bluetooth-rfkill-event.service b/bluetooth-rfkill-event/bluetooth-rfkill-event.service
+index 453fd36..7f7c377 100644
+--- a/bluetooth-rfkill-event/bluetooth-rfkill-event.service
++++ b/bluetooth-rfkill-event/bluetooth-rfkill-event.service
+@@ -10,4 +10,4 @@ ExecStart=/usr/sbin/bluetooth_rfkill_event $DEBUG $BTMODULE $CONFIGFILE
+ Restart=on-failure
+ 
+ [Install]
+-WantedBy=bluetooth.target
++WantedBy=multi-user.target

--- a/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0004-Remove-sysconfig-file.patch
+++ b/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0004-Remove-sysconfig-file.patch
@@ -1,0 +1,53 @@
+From fec91792d46e86900975f79b94f23c7ef9d1ffc1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Fri, 3 Feb 2023 23:10:55 +0100
+Subject: [PATCH] Remove sysconfig file.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This file should be provided by the different platforms, hence remove it here as it's not needed.
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ bluetooth-rfkill-event/Makefile                         | 2 --
+ bluetooth-rfkill-event/bluetooth-rfkill-event.service   | 2 +-
+ bluetooth-rfkill-event/bluetooth-rfkill-event.sysconfig | 4 ----
+ 3 files changed, 1 insertion(+), 7 deletions(-)
+ delete mode 100644 bluetooth-rfkill-event/bluetooth-rfkill-event.sysconfig
+
+diff --git a/bluetooth-rfkill-event/Makefile b/bluetooth-rfkill-event/Makefile
+index f1a580f..fd8c545 100644
+--- a/bluetooth-rfkill-event/Makefile
++++ b/bluetooth-rfkill-event/Makefile
+@@ -32,7 +32,5 @@ install:
+ 	mkdir -p $(INSTALL_ROOT)/usr/lib/systemd/system/network.target.wants
+ 	ln -s ../bluetooth-rfkill-event.service $(INSTALL_ROOT)/usr/lib/systemd/system/network.target.wants/bluetooth-rfkill-event.service
+ 	mkdir -p $(INSTALL_ROOT)/etc/bluetooth-rfkill-event
+-	mkdir -p $(INSTALL_ROOT)/etc/sysconfig
+-	install bluetooth-rfkill-event.sysconfig $(INSTALL_ROOT)/etc/sysconfig/bluetooth-rfkill-event
+ 	mkdir -p $(INSTALL_ROOT)$(RFKILL_HELPER_PATH)
+ 	install -m 775 killall-wait.sh $(INSTALL_ROOT)$(RFKILL_HELPER_PATH)/killall-wait.sh
+diff --git a/bluetooth-rfkill-event/bluetooth-rfkill-event.service b/bluetooth-rfkill-event/bluetooth-rfkill-event.service
+index 7f7c377..e628db2 100644
+--- a/bluetooth-rfkill-event/bluetooth-rfkill-event.service
++++ b/bluetooth-rfkill-event/bluetooth-rfkill-event.service
+@@ -6,7 +6,7 @@ Before=bluetooth.service
+ Type=simple
+ EnvironmentFile=-/etc/sysconfig/bluetooth-rfkill-event
+ EnvironmentFile=-/etc/sysconfig/bluetooth-rfkill-event-hciattach
+-ExecStart=/usr/sbin/bluetooth_rfkill_event $DEBUG $BTMODULE $CONFIGFILE
++ExecStart=/usr/sbin/bluetooth_rfkill_event $DEBUG $BTMODULE $CONFIGFILE $OPTIONS
+ Restart=on-failure
+ 
+ [Install]
+diff --git a/bluetooth-rfkill-event/bluetooth-rfkill-event.sysconfig b/bluetooth-rfkill-event/bluetooth-rfkill-event.sysconfig
+deleted file mode 100644
+index 64f296c..0000000
+--- a/bluetooth-rfkill-event/bluetooth-rfkill-event.sysconfig
++++ /dev/null
+@@ -1,4 +0,0 @@
+-# Can be used to configure the following:
+-# DEBUG -- debug options
+-# BTMODULE -- name of bluetooth kernel module to load/unload, if any
+-# CONFIGFILE -- name of configuration file to use

--- a/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0005-Install-systemd-service-to-lib-systemd-system.patch
+++ b/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0005-Install-systemd-service-to-lib-systemd-system.patch
@@ -1,0 +1,32 @@
+From 9b03aecd589f591999923f446c39fdff011e27eb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Fri, 3 Feb 2023 23:15:12 +0100
+Subject: [PATCH] Install systemd service to /lib/systemd/system/.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+OE expects the systemd service file at this location rather than the /usr directory.
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ bluetooth-rfkill-event/Makefile | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/bluetooth-rfkill-event/Makefile b/bluetooth-rfkill-event/Makefile
+index fd8c545..c088b36 100644
+--- a/bluetooth-rfkill-event/Makefile
++++ b/bluetooth-rfkill-event/Makefile
+@@ -27,10 +27,8 @@ all: bluetooth_rfkill_event
+ install:
+ 	mkdir -p $(INSTALL_ROOT)/usr/sbin
+ 	install bluetooth_rfkill_event $(INSTALL_ROOT)/usr/sbin
+-	mkdir -p $(INSTALL_ROOT)/usr/lib/systemd/system
+-	install bluetooth-rfkill-event.service $(INSTALL_ROOT)/usr/lib/systemd/system
+-	mkdir -p $(INSTALL_ROOT)/usr/lib/systemd/system/network.target.wants
+-	ln -s ../bluetooth-rfkill-event.service $(INSTALL_ROOT)/usr/lib/systemd/system/network.target.wants/bluetooth-rfkill-event.service
++	mkdir -p $(INSTALL_ROOT)/lib/systemd/system
++	install bluetooth-rfkill-event.service $(INSTALL_ROOT)/lib/systemd/system
+ 	mkdir -p $(INSTALL_ROOT)/etc/bluetooth-rfkill-event
+ 	mkdir -p $(INSTALL_ROOT)$(RFKILL_HELPER_PATH)
+ 	install -m 775 killall-wait.sh $(INSTALL_ROOT)$(RFKILL_HELPER_PATH)/killall-wait.sh

--- a/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event_git.bb
+++ b/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event_git.bb
@@ -1,0 +1,31 @@
+SUMMARY = "Bluetooth rfkill daemon, loads the Bluetooth firmware."
+HOMEPAGE = "https://github.com/mer-hybris/bluetooth-rfkill-event"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://../COPYING;md5=22b918b77fd38d7d7651669e03bdfd10"
+
+SRC_URI = "git://github.com/mer-hybris/bluetooth-rfkill-event.git;protocol=https;branch=master \
+           file://0001-Add-support-for-using-a-custom-rfkill-device.patch;patchdir=.. \
+           file://0002-Store-custom-Bluetooth-address.patch;patchdir=.. \
+           file://0003-Fix-loading-the-service-file.patch;patchdir=.. \
+           file://0004-Remove-sysconfig-file.patch;patchdir=.. \
+           file://0005-Install-systemd-service-to-lib-systemd-system.patch;patchdir=.. \
+           "
+SRCREV = "f411db38e8f6b49403f2e9a320083630f990bcbc"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git/bluetooth-rfkill-event"
+
+DEPENDS += "glib-2.0 bluez5"
+RDEPENDS:${PN} += "rfkill bluetooth-rfkill-event-configs"
+
+inherit pkgconfig
+inherit systemd
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "bluetooth-rfkill-event.service"
+
+do_install() {
+	oe_runmake install INSTALL_ROOT=${D}
+}
+
+FILES:${PN} += "${datadir}/libexec/bluetooth_rfkill_event/killall-wait.sh"


### PR DESCRIPTION
bluetooth-rfkill-event can be used to call brcm-patchram-plus whenever the Bluetooth device becomes available via rfkill.
It includes the ability to set the Bluetooth address as well.
Some minor additions have been made to store the randomized Bluetooth address in case there isn't one stored.
It also needed some patching so that we can supply our own rfkill device.

Eventually I'd like to remove the special `brcm-patchram-plus` compile time macros and allow https://github.com/AsteroidOS/brcm-patchram-plus/blob/master/src/main.c#L263 to be configurable via the config files.

See https://github.com/AsteroidOS/meta-smartwatch/pull/155 for device specific changes that need to be applied.

This fixes https://github.com/AsteroidOS/meta-smartwatch/issues/114.