### PR TITLE
Remove default armv7 tune.

### DIFF
--- a/conf/machine/include/hybris-watch.inc
+++ b/conf/machine/include/hybris-watch.inc
@@ -15,5 +15,3 @@ IMAGE_FSTYPES += "ext4"
 IMAGE_ROOTFS_ALIGNMENT="4"
 
 IMAGE_INSTALL += "android-tools-adbd android-system firmwared"
-
-DEFAULTTUNE = "armv7vehf-neon"


### PR DESCRIPTION
Given that the hybris-watch.inc file makes no mention of being architecture-specific, it does not make sense for it to be setting an armv7-specific processor tune. This, along with [the corresponding commit in meta-smartwatch](https://github.com/AsteroidOS/meta-smartwatch/pull/158), moves this parameter to machine-specific conf files, which should allow hybris-watch.inc to be used by watches with processor architectures other than armv7, without unnecessarily overriding the defaulttune. The PR to meta-smartwatch should be merged first. 