### PR TITLE
initramfs-scripts-android: Wait on the sdcard partition rather than mmcblk0

### DIFF
--- a/recipes-core/initrdscripts/initramfs-scripts-android/init.sh
+++ b/recipes-core/initrdscripts/initramfs-scripts-android/init.sh
@@ -74,8 +74,8 @@ fi
 info "Mounting sdcard..."
 mkdir -m 0777 /sdcard /loop
 
-while [ ! -e /sys/block/mmcblk0 ] ; do
-    info "Waiting for mmcblk0..."
+while [ ! -e /dev/$sdcard_partition ] ; do
+    info "Waiting for $sdcard_partition..."
     sleep 1
 done
 


### PR DESCRIPTION
The sdcard partition can be on another block device and there's no point hard-coding a device when we have $sdcard_partition at our disposal anyway.