### PR TITLE
Allow ceres user to use dbus introspection

### DIFF
--- a/recipes-connectivity/connman/connman/connman-dbus.conf
+++ b/recipes-connectivity/connman/connman/connman-dbus.conf
@@ -11,6 +11,9 @@
     <policy at_console="true">
         <allow send_destination="net.connman"/>
     </policy>
+    <policy user="ceres">
+        <allow send_destination="net.connman"/>
+    </policy>
     <policy context="default">
         <deny send_destination="net.connman"/>
         <allow send_interface="net.connman.Clock"/>


### PR DESCRIPTION
This fixes a bug that prevented the ceres user from being able to use introspection of connman which contributed to not being able to use libconnman-qt5 as used in the asteroid-weather-glow watchface.  This is the other part of the fix for https://github.com/AsteroidOS/asteroid/issues/243 