### PR TITLE
Register dbus types in NetworkTechnology

### DIFF
--- a/recipes-connectivity/libconnman-qt/libconnman-qt5/0002-Register-dbus-types-in-networktechnology.patch
+++ b/recipes-connectivity/libconnman-qt/libconnman-qt5/0002-Register-dbus-types-in-networktechnology.patch
@@ -1,0 +1,35 @@
+From 024c8839ef3912d0ce9326fa482888a56d1d48b3 Mon Sep 17 00:00:00 2001
+From: Ed Beroset <beroset@ieee.org>
+Date: Wed, 29 Mar 2023 11:32:50 -0400
+Subject: [PATCH] Register dbus types in networktechnology
+
+In some uses of connman, including in analog-weather-glow watchface, the
+NetworkTechnology object was before the DBus types were registered. This
+fixes that problem by making sure registerCommonDataTypes() is called
+from within each version of constructor.
+
+Signed-off-by: Ed Beroset <beroset@ieee.org>
+---
+ libconnman-qt/networktechnology.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/libconnman-qt/networktechnology.cpp b/libconnman-qt/networktechnology.cpp
+index 130b681..838001d 100644
+--- a/libconnman-qt/networktechnology.cpp
++++ b/libconnman-qt/networktechnology.cpp
+@@ -37,6 +37,7 @@ NetworkTechnology::NetworkTechnology(const QString &path, const QVariantMap &pro
+     Q_ASSERT(!path.isEmpty());
+     m_propertiesCache = properties;
+ 
++    registerCommonDataTypes();
+     startDBusWatching();
+     initialize();
+     setPath(path);
+@@ -49,6 +50,7 @@ NetworkTechnology::NetworkTechnology(QObject* parent)
+                                             QDBusServiceWatcher::WatchForRegistration
+                                             | QDBusServiceWatcher::WatchForUnregistration, this))
+ {
++    registerCommonDataTypes();
+     startDBusWatching();
+     initialize();
+ }

--- a/recipes-connectivity/libconnman-qt/libconnman-qt5_%.bbappend
+++ b/recipes-connectivity/libconnman-qt/libconnman-qt5_%.bbappend
@@ -1,5 +1,7 @@
 SRCREV = "1.3.2"
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://0001-Wait-for-dbus-call-to-finish-in-NetworkTechnology.patch"
+SRC_URI += "file://0001-Wait-for-dbus-call-to-finish-in-NetworkTechnology.patch \
+            file://0002-Register-dbus-types-in-networktechnology.patch \
+            "
 


### PR DESCRIPTION
The libconnman-qt5 code's NetworkTechnology object, used by the analog-weather-glow watchface, sometimes attempted to use dbus types that were not yet registered.  This fixes that and is the final piece to fix https://github.com/AsteroidOS/asteroid/issues/243 by registering the types in every version of the NetworkTechnology constructor rather than only within the NetworkManager constructor.