### PR TITLE
lcd-tools: remove `COMPATIBLE_MACHINE`

### DIFF
--- a/recipes-core/lcd-tools/lcd-tools.bb
+++ b/recipes-core/lcd-tools/lcd-tools.bb
@@ -12,7 +12,7 @@ S = "${WORKDIR}/git"
 DEPENDS = "libhybris cli11 mlite qtbase"
 inherit cmake_qt5 pkgconfig
 PACKAGE_ARCH = "${MACHINE_ARCH}"
-COMPATIBLE_MACHINE = "catfish"
+COMPATIBLE_MACHINE = "catfish|koi"
 
 do_install:append() {
     install -d ${D}/usr/lib/systemd/user/


### PR DESCRIPTION
koi has now been added as to meta-smartwatch. support for it has existed in lcd-tools for a while now, so now seems like an appropriate time to declare it compatible. 