### PR TITLE
Provide a generic Android O patched libaries and fix Android Pie inconsistency.

### DIFF
--- a/recipes-android/android/android.inc
+++ b/recipes-android/android/android.inc
@@ -23,9 +23,12 @@ do_install() {
     rm ${D}${includedir}/android/android-headers.pc
 }
 
-# FIXME: QA Issue: Architecture did not match (40 to 164) on /work/dory-oe-linux-gnueabi/android/lollipop-r0/packages-split/android-system/system/vendor/firmware/adsp.b00 [arch]
+# Precompiled libraries, INSANE_SKIP all.
 do_package_qa() {
 }
+
+# Allow empty main package since the -dev package depends on it
+ALLOW_EMPTY:${PN} = "1"
 
 PACKAGES =+ "android-system android-headers"
 FILES:android-system = "/usr"

--- a/recipes-android/android/android_armv7-oreo.bb
+++ b/recipes-android/android/android_armv7-oreo.bb
@@ -1,0 +1,9 @@
+SUMMARY = "Downloads the Andrdoid armv7 Oreo with hwcomposer patches for the Snapdragon Wear 2100/3100 platform /usr/libexec/hal-droid and /usr/include/android folders and installs them for libhybris"
+LICENSE = "CLOSED"
+
+SRC_URI = "https://dl.dropboxusercontent.com/s/4d8pkmd62rxl464/hybris-o-msm8909.tar.gz"
+SRC_URI[md5sum] = "039a387a3e4ccd09d28b05195280d162"
+SRC_URI[sha256sum] = "ddc725dd280d8c5f546ff47f727b67ea99def9a4883edeebfe0edfdc5a61a636"
+PV = "armv7+oreo"
+
+require android.inc

--- a/recipes-android/android/android_armv7-pie32.bb
+++ b/recipes-android/android/android_armv7-pie32.bb
@@ -1,9 +1,9 @@
-SUMMARY = "Downloads the Snapdragon Wear 2100 /usr/libexec/hal-droid and /usr/include/android folders and installs them for libhybris"
+SUMMARY = "Downloads the Andrdoid armv7 Pie with 32-bit binder /usr/libexec/hal-droid and /usr/include/android folders and installs them for libhybris"
 LICENSE = "CLOSED"
 
 SRC_URI = "https://dl.dropboxusercontent.com/s/xhtzxu3i1rj550x/hybris-p-msm8909.tar.gz"
 SRC_URI[md5sum] = "498f109103d8442ad9c0308da9109cc1"
 SRC_URI[sha256sum] = "a13c40696d905076f71a5edc9810c40e628428c6eb4d4bd46d66b9c0c705db4d"
-PV = "msm8909+pie"
+PV = "armv7+pie32"
 
 require android.inc

--- a/recipes-android/android/android_armv7-pie64.bb
+++ b/recipes-android/android/android_armv7-pie64.bb
@@ -1,9 +1,9 @@
-SUMMARY = "Downloads the Snapdragon Wear 3100 /usr/libexec/hal-droid and /usr/include/android folders and installs them for libhybris"
+SUMMARY = "Downloads the Andrdoid armv7 Pie with 64-bit binder /usr/libexec/hal-droid and /usr/include/android folders and installs them for libhybris"
 LICENSE = "CLOSED"
 
 SRC_URI = "https://dl.dropboxusercontent.com/s/2btck4hlowhronv/hybris-p-msm8909w.tar.gz"
 SRC_URI[md5sum] = "cc084ae844473e074f06391033a08c46"
 SRC_URI[sha256sum] = "d7d91700007795aedcdf4fffa418552edf2b3fd41a0223367401906f4f4dfed3"
-PV = "msm8909w+pie"
+PV = "armv7+pie64"
 
 require android.inc


### PR DESCRIPTION
Provides a generic Android Oreo libhybris recipe instead of polluting the `meta-smartwatch` repo with he same `SRCREV`. This is the same one used by the `koi` port. Which contains some additional fixes to avoid TLS region conflicts with updated versions of libhybris.

Additionally, this changes the naming of the `msm8909+pie` and `msm8909w+pie` recipes as they are both compatible with `msm8909w`. The only difference is that one is targeting a 32-bit binder while the other targets a 64-bit binder.

Reason for this PR still being a draft is because I need to test if this works on the watches I own.