### PR TITLE
Add polkit to allow time change

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -15,8 +15,9 @@ qtgraphicaleffects-qmlplugins supported-languages ttf-asteroid-fonts asteroid-la
 
 EXTRA_USERS_PARAMS = "groupadd system; \
                       groupadd gps; \
+                      groupadd datetime; \
                       groupadd -f -g 1024 mtp; \
-                      useradd -p '' -G 'audio,video,system,wheel,gps,sailfish-datetime,mtp,users' ceres"
+                      useradd -p '' -G 'audio,video,system,wheel,gps,sailfish-datetime,datetime,mtp,users' ceres"
 
 IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_ROOTFS_EXTRA_SPACE = "131072"

--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -8,7 +8,8 @@ inherit populate_sdk_qt5
 IMAGE_FEATURES += "package-management debug-tweaks"
 
 IMAGE_INSTALL += " \
-kernel-modules base-files base-passwd systemd busybox iproute2 connman pam-plugin-loginuid bluez5 pulseaudio-server openssh-sshd openssh-sftp-server openssh-scp dsme mce ngfd nfcd timed sensorfw resize-rootfs mapplauncherd-booster-qtcomponents usb-moded ofono \
+kernel-modules base-files base-passwd systemd busybox iproute2 connman pam-plugin-loginuid bluez5 polkit polkit-group-rule-datetime \
+pulseaudio-server openssh-sshd openssh-sftp-server openssh-scp dsme mce ngfd nfcd timed sensorfw resize-rootfs mapplauncherd-booster-qtcomponents usb-moded ofono \
 ${@oe.utils.conditional('MACHINE_HAS_WLAN', 'true', 'iproute2 wpa-supplicant connman-client', '', d)} \
 qtgraphicaleffects-qmlplugins supported-languages ttf-asteroid-fonts asteroid-launcher asteroid-calculator asteroid-calendar asteroid-stopwatch asteroid-settings asteroid-timer asteroid-alarmclock asteroid-weather asteroid-music asteroid-btsyncd asteroid-flashlight asteroid-diamonds"
 

--- a/conf/distro/asteroid.conf
+++ b/conf/distro/asteroid.conf
@@ -20,7 +20,7 @@ DISTRO = "asteroid"
 DISTRO_NAME = "AsteroidOS"
 DISTRO_VERSION ?= "1.1-nightly"
 
-DISTRO_FEATURES = "alsa bluetooth bluez5 opengl pam pulseaudio systemd usbhost usbgadget wayland wifi xattr ${DISTRO_FEATURES_LIBC}"
+DISTRO_FEATURES = "alsa bluetooth bluez5 opengl pam polkit pulseaudio systemd usbhost usbgadget wayland wifi xattr ${DISTRO_FEATURES_LIBC}"
 
 PREFERRED_PROVIDER_jpeg = "libjpeg-turbo"
 PREFERRED_PROVIDER_jpeg-native = "libjpeg-turbo-native"


### PR DESCRIPTION
This PR is a prerequisite to being able to apply https://github.com/AsteroidOS/asteroid-settings/pull/63 by adding `polkit` and the polkit rule that allows the `ceres` user to change the time, date, and timezone.