### PR TITLE
ttf-asteroid-fonts: Fix license checksum.

### DIFF
--- a/recipes-graphics/ttf-fonts/ttf-asteroid-fonts_git.bb
+++ b/recipes-graphics/ttf-fonts/ttf-asteroid-fonts_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "AsteroidOS fonts set"
 SECTION = "fonts"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-fonts"
 LICENSE = "OFL-1.1 & Apache-2.0 & CC-BY-3.0 & CC-BY-4.0 & MIT"
-LIC_FILES_CHKSUM = "file://README.md;beginline=6;endline=18;md5=fb826a80b8f8e5dcf80e37e736ceed7e"
+LIC_FILES_CHKSUM = "file://README.md;beginline=9;endline=24;md5=bc7ac047345eed00593ad8f5400740a5"
 PR = "r0"
 INHIBIT_DEFAULT_DEPS = "1"
 


### PR DESCRIPTION
Stock images are now shipped with more fonts (https://github.com/AsteroidOS/asteroid-fonts/commit/341a7ac195ed953c0843b72cc98db9d539a5c993), this resulted into an update of the license text used in the readme.

Currently, `Arkhip` uses a license that's not available in the SPDX License list. We might have to alter this at some point as well.