### PR TITLE
android-init: Set sys.boot_completed propery.

### DIFF
--- a/recipes-android/android-init/android-init/android-boot-completed.service
+++ b/recipes-android/android-init/android-init/android-boot-completed.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Tells the Android init system that the boot has been completed.
+ConditionUser=!root
+After=asteroid-launcher.service
+
+[Service]
+Type=simple
+ExecStartPre=-/bin/sleep 10
+ExecStart=/bin/sh -ec 'if [ `getprop sys.boot_completed` != '1' ]; then setprop sys.boot_completed 1; fi'
+
+[Install]
+WantedBy=default.target

--- a/recipes-android/android-init/android-init_1.0.bb
+++ b/recipes-android/android-init/android-init_1.0.bb
@@ -1,7 +1,8 @@
 DESCRIPTION = "This installs an android-init service which loads /system/bin/init with the /init.rc file which loads logd and servicemanager"
 PR = "r0"
 SRC_URI = "file://init.rc \
-    file://android-init.service"
+    file://android-init.service \
+    file://android-boot-completed.service"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 S = "${WORKDIR}"
@@ -11,9 +12,15 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 do_install() {
     install -m 0644 ${WORKDIR}/init.rc ${D}/init.rc
 
-    install -d ${D}/lib/systemd/system/multi-user.target.wants/
-    cp ${WORKDIR}/android-init.service ${D}/lib/systemd/system/
-    ln -s ../android-init.service ${D}/lib/systemd/system/multi-user.target.wants/android-init.service
+    install -d ${D}${systemd_unitdir}/multi-user.target.wants/
+    install -m 0644 ${WORKDIR}/android-init.service  ${D}${systemd_unitdir}/
+    ln -s ../android-init.service ${D}${systemd_unitdir}/multi-user.target.wants/android-init.service
+
+    install -d ${D}${systemd_user_unitdir}/default.target.wants/
+    install -m 0644 ${WORKDIR}/android-boot-completed.service  ${D}${systemd_user_unitdir}/
+    if [ ! -f ${D}${systemd_user_unitdir}/default.target.wants/android-boot-completed.service ]; then
+        ln -s ${systemd_user_unitdir}/android-boot-completed.service ${D}${systemd_user_unitdir}/default.target.wants/android-boot-completed.service
+    fi
 }
 
-FILES:${PN} += "/init.rc /lib/systemd/system/"
+FILES:${PN} += "/init.rc ${systemd_unitdir} ${systemd_user_unitdir}"


### PR DESCRIPTION
Some Android init scripts use the `sys.boot_completed` property to perform actions after the boot has been completed. Normally this property is set from the Android SystemServer (Java daemon) which is not available under AsteroidOS. Instead provide a simple systemd script that sets this property.

An example of a `sys.boot_completed` is as follows:
```
on property:sys.boot_completed=1
    write /sys/devices/system/cpu/cpu1/online 1
    write /sys/devices/system/cpu/cpu2/online 0
    write /sys/devices/system/cpu/cpu3/online 0
```

Eventually this could help with:
- Removing the `wifi-enabler.services` on some ports. (https://github.com/AsteroidOS/meta-smartwatch/blob/7e59733478d31b5244dfdc61baef8ec5f4fb539a/meta-beluga/recipes-android/wifi-enabler/wifi-enabler/wifi-enabler.service, https://github.com/AsteroidOS/meta-smartwatch/blob/7e59733478d31b5244dfdc61baef8ec5f4fb539a/meta-ray/recipes-android/wifi-enabler/wifi-enabler/wifi-enabler.service)
- Remove the port specific `underclock.service` used on pretty much all ports.