### PR TITLE
android-init: Fix install path of the android-init.service.

### DIFF
--- a/recipes-android/android-init/android-init_1.0.bb
+++ b/recipes-android/android-init/android-init_1.0.bb
@@ -12,9 +12,9 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 do_install() {
     install -m 0644 ${WORKDIR}/init.rc ${D}/init.rc
 
-    install -d ${D}${systemd_unitdir}/multi-user.target.wants/
-    install -m 0644 ${WORKDIR}/android-init.service  ${D}${systemd_unitdir}/
-    ln -s ../android-init.service ${D}${systemd_unitdir}/multi-user.target.wants/android-init.service
+    install -d ${D}${systemd_system_unitdir}/multi-user.target.wants/
+    install -m 0644 ${WORKDIR}/android-init.service  ${D}${systemd_system_unitdir}/
+    ln -s ../android-init.service ${D}${systemd_system_unitdir}/multi-user.target.wants/android-init.service
 
     install -d ${D}${systemd_user_unitdir}/default.target.wants/
     install -m 0644 ${WORKDIR}/android-boot-completed.service  ${D}${systemd_user_unitdir}/
@@ -23,4 +23,4 @@ do_install() {
     fi
 }
 
-FILES:${PN} += "/init.rc ${systemd_unitdir} ${systemd_user_unitdir}"
+FILES:${PN} += "/init.rc ${systemd_system_unitdir} ${systemd_user_unitdir}"


### PR DESCRIPTION
https://github.com/AsteroidOS/meta-asteroid/commit/06dc67571b21cb2f6ec3e2924cd06a9b354e073d introduced a change where the android-init service file would install to a location using the Yocto system package variables. This however turned out to be the incorrect variable.

The `systemd_unitdir` variable is not the correct path to install systemd unit files (it represents the /lib/systemd/ path).
Instead use `systemd_system_unitdir` variable to install the systemd unit file into the correct path (/lib/systemd/system/).