### PR TITLE
ttf-asteroid-fonts: Update license checksum.

### DIFF
--- a/recipes-graphics/ttf-fonts/ttf-asteroid-fonts_git.bb
+++ b/recipes-graphics/ttf-fonts/ttf-asteroid-fonts_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "AsteroidOS fonts set"
 SECTION = "fonts"
 HOMEPAGE = "https://github.com/AsteroidOS/asteroid-fonts"
 LICENSE = "OFL-1.1 & Apache-2.0 & CC-BY-3.0 & CC-BY-4.0 & MIT"
-LIC_FILES_CHKSUM = "file://README.md;beginline=9;endline=24;md5=bc7ac047345eed00593ad8f5400740a5"
+LIC_FILES_CHKSUM = "file://README.md;beginline=9;endline=25;md5=57521b48e8a4e517fea19e4c36b11e18"
 PR = "r0"
 INHIBIT_DEFAULT_DEPS = "1"
 


### PR DESCRIPTION
Stock images are now shipped with more fonts as part of a new stock watchface (https://github.com/AsteroidOS/asteroid-fonts/pull/16), this resulted into an update of the license text used in the readme.