### PR TITLE
initramfs-scripts-android: Add userdata root to the ext4 search path.

### DIFF
--- a/recipes-core/initrdscripts/initramfs-scripts-android/init.sh
+++ b/recipes-core/initrdscripts/initramfs-scripts-android/init.sh
@@ -89,6 +89,10 @@ if [ -d /sdcard/media/0 ] ; then
     ANDROID_MEDIA_DIR="/sdcard/media/0"
 fi
 
+if [ -e /sdcard/asteroidos.ext4 ] ; then
+    ANDROID_MEDIA_DIR="/sdcard/"
+fi
+
 BOOT_DIR="/sdcard"
 if [ -e $ANDROID_MEDIA_DIR/asteroidos.ext4 ] ; then
     /sbin/fsck.ext4 -p $ANDROID_MEDIA_DIR/asteroidos.ext4


### PR DESCRIPTION
The userdata partition is partially encrypted on newer watches. In most cases the root of the userdata partition isn't encrypted, but everything in the `media` folder is encrypted. This adds the root of the userdata partition as a valid location for the ext4, but it means that the ext4 image needs to be pushed externally (i.e. on first boot of the AsteroidOS kernel).