### PR TITLE
asteroid-apps: Install library files.

### DIFF
--- a/recipes-asteroid/asteroid-alarmclock/asteroid-alarmclock_git.bb
+++ b/recipes-asteroid/asteroid-alarmclock/asteroid-alarmclock_git.bb
@@ -12,4 +12,4 @@ inherit cmake_qt5 pkgconfig
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native nemo-qml-plugin-alarms qttools-native qtdeclarative-native"
 RDEPENDS:${PN} += "nemo-qml-plugin-alarms"
-FILES:${PN} += "/usr/share/translations/ /usr/lib/systemd/user/alarmpresenter.service /usr/share/dbus-1/services/com.nokia.voland.service"
+FILES:${PN} += "/usr/share/translations/ ${libdir}/asteroid-alarmclock.so /usr/lib/systemd/user/alarmpresenter.service /usr/share/dbus-1/services/com.nokia.voland.service"

--- a/recipes-asteroid/asteroid-calculator/asteroid-calculator_git.bb
+++ b/recipes-asteroid/asteroid-calculator/asteroid-calculator_git.bb
@@ -11,6 +11,7 @@ S = "${WORKDIR}/git"
 inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native qtdeclarative-native qttools-native"
+FILES:${PN} += "${libdir}/asteroid-calculator.so"
 
 do_install:append() {
     # This app only uses translations for the desktop shortcut.

--- a/recipes-asteroid/asteroid-calendar/asteroid-calendar_git.bb
+++ b/recipes-asteroid/asteroid-calendar/asteroid-calendar_git.bb
@@ -12,4 +12,4 @@ inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native nemo-qml-plugin-calendar qttools-native qtdeclarative-native"
 RDEPENDS:${PN} += "nemo-qml-plugin-calendar"
-FILES:${PN} += "/usr/share/translations/"
+FILES:${PN} += "/usr/share/translations/ ${libdir}/asteroid-calendar.so"

--- a/recipes-asteroid/asteroid-camera/asteroid-camera_git.bb
+++ b/recipes-asteroid/asteroid-camera/asteroid-camera_git.bb
@@ -12,6 +12,7 @@ inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native qtmultimedia"
 RDEPENDS:${PN} += "qtmultimedia"
+FILES:${PN} += "${libdir}/asteroid-camera.so"
 
 do_install:append() {
     # This app only uses translations for the desktop shortcut.

--- a/recipes-asteroid/asteroid-compass/asteroid-compass_git.bb
+++ b/recipes-asteroid/asteroid-compass/asteroid-compass_git.bb
@@ -12,4 +12,4 @@ inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"
 RDEPENDS:${PN} += "qtsensors qtsensors-qmlplugins qtsensors-plugins"
-FILES:${PN} += "/usr/share/translations/"
+FILES:${PN} += "/usr/share/translations/ ${libdir}/asteroid-compass.so"

--- a/recipes-asteroid/asteroid-diamonds/asteroid-diamonds_git.bb
+++ b/recipes-asteroid/asteroid-diamonds/asteroid-diamonds_git.bb
@@ -12,5 +12,6 @@ inherit cmake_qt5
 
 FILES:${PN} += "/usr/share/icons/asteroid/"
 FILES:${PN} += "/usr/share/translations/"
+FILES:${PN} += "${libdir}/asteroid-diamonds.so"
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"

--- a/recipes-asteroid/asteroid-flashlight/asteroid-flashlight_git.bb
+++ b/recipes-asteroid/asteroid-flashlight/asteroid-flashlight_git.bb
@@ -11,4 +11,4 @@ S = "${WORKDIR}/git"
 inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"
-FILES:${PN} += "/usr/share/translations/"
+FILES:${PN} += "/usr/share/translations/ ${libdir}/asteroid-flashlight.so"

--- a/recipes-asteroid/asteroid-gps/asteroid-gps_git.bb
+++ b/recipes-asteroid/asteroid-gps/asteroid-gps_git.bb
@@ -12,6 +12,7 @@ inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native qtlocation qttools-native qtdeclarative-native"
 RDEPENDS:${PN} += "qtlocation"
+FILES:${PN} += "${libdir}/asteroid-gps-test.so"
 
 do_install:append() {
     # This app only uses translations for the desktop shortcut.

--- a/recipes-asteroid/asteroid-hrm/asteroid-hrm_git.bb
+++ b/recipes-asteroid/asteroid-hrm/asteroid-hrm_git.bb
@@ -11,4 +11,4 @@ S = "${WORKDIR}/git"
 inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native qtsensors qttools-native qtdeclarative-native"
-FILES:${PN} += "/usr/share/translations/"
+FILES:${PN} += "/usr/share/translations/ ${libdir}/asteroid-hrm.so"

--- a/recipes-asteroid/asteroid-music/asteroid-music_git.bb
+++ b/recipes-asteroid/asteroid-music/asteroid-music_git.bb
@@ -12,4 +12,4 @@ inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native qtmpris qttools-native qtdeclarative-native"
 RDEPENDS:${PN} += "qtmpris"
-FILES:${PN} += "/usr/share/translations/"
+FILES:${PN} += "/usr/share/translations/ ${libdir}/asteroid-music.so"

--- a/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
+++ b/recipes-asteroid/asteroid-settings/asteroid-settings_git.bb
@@ -12,4 +12,4 @@ inherit cmake_qt5 pkgconfig
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus qttools-native qtdeclarative-native"
 RDEPENDS:${PN} += "nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus qtmultimedia-qmlplugins libconnman-qt5-qmlplugins"
-FILES:${PN} += "/usr/share/translations/"
+FILES:${PN} += "/usr/share/translations/ ${libdir}/asteroid-settings.so"

--- a/recipes-asteroid/asteroid-stopwatch/asteroid-stopwatch_git.bb
+++ b/recipes-asteroid/asteroid-stopwatch/asteroid-stopwatch_git.bb
@@ -11,6 +11,7 @@ S = "${WORKDIR}/git"
 inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"
+FILES:${PN} += "${libdir}/asteroid-stopwatch.so"
 
 do_install:append() {
     # This app only uses translations for the desktop shortcut.

--- a/recipes-asteroid/asteroid-timer/asteroid-timer_git.bb
+++ b/recipes-asteroid/asteroid-timer/asteroid-timer_git.bb
@@ -12,6 +12,7 @@ inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native nemo-qml-plugin-dbus nemo-keepalive qttools-native qtdeclarative-native"
 RDEPENDS:${PN} += "nemo-keepalive"
+FILES:${PN} += "${libdir}/asteroid-timer.so"
 
 do_install:append() {
     # This app only uses translations for the desktop shortcut.

--- a/recipes-asteroid/asteroid-weather/asteroid-weather_git.bb
+++ b/recipes-asteroid/asteroid-weather/asteroid-weather_git.bb
@@ -12,4 +12,4 @@ inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native nemo-qml-plugin-configuration qttools-native qtdeclarative-native"
 RDEPENDS:${PN} += "nemo-qml-plugin-configuration"
-FILES:${PN} += "/usr/share/translations/"
+FILES:${PN} += "/usr/share/translations/ ${libdir}/asteroid-weather.so"


### PR DESCRIPTION
AsteroidOS applications previously installed a library to `/usr/bin`. This was due to legacy reasons. Recently, this has been solved by instead providing a script that executes the `invoker` with the proper `/usr/lib/asteroid-<app>.so`.


Relevant other PRs:
- https://github.com/AsteroidOS/qml-asteroid/pull/45
- https://github.com/AsteroidOS/asteroid-gps-test/pull/4
- https://github.com/AsteroidOS/asteroid-weather/pull/20
- https://github.com/AsteroidOS/asteroid-timer/pull/17
- https://github.com/AsteroidOS/asteroid-stopwatch/pull/11
- https://github.com/AsteroidOS/asteroid-settings/pull/86
- https://github.com/AsteroidOS/asteroid-music/pull/24
- https://github.com/AsteroidOS/asteroid-hrm/pull/11
- https://github.com/AsteroidOS/asteroid-helloworld/pull/8
- https://github.com/AsteroidOS/asteroid-flashlight/pull/14
- https://github.com/AsteroidOS/asteroid-diamonds/pull/13
- https://github.com/AsteroidOS/asteroid-compass/pull/8
- https://github.com/AsteroidOS/asteroid-camera/pull/5
- https://github.com/AsteroidOS/asteroid-calendar/pull/22
- https://github.com/AsteroidOS/asteroid-calculator/pull/8
- https://github.com/AsteroidOS/asteroid-alarmclock/pull/20