### PR TITLE
Add patch to allow clean compile

### DIFF
--- a/recipes-devtools/rust/rust-llvm/0003-Add-necessary-include-file.patch
+++ b/recipes-devtools/rust/rust-llvm/0003-Add-necessary-include-file.patch
@@ -1,0 +1,25 @@
+From e54d6b19a7645add24e15087c58091a3df3ef1dd Mon Sep 17 00:00:00 2001
+From: Ed Beroset <beroset@ieee.org>
+Date: Sat, 20 May 2023 08:22:16 -0400
+Subject: [PATCH] Add necessary include file
+
+The cstdint include is needed for the definition of uintptr_t.
+
+Upstream-Status: Committed [https://github.com/llvm/llvm-project/commit/ff1681ddb303223973653f7f5f3f3435b48a1983]
+Signed-off-by: Ed Beroset <beroset@ieee.org>
+---
+ src/llvm-project/llvm/include/llvm/Support/Signals.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/llvm-project/llvm/include/llvm/Support/Signals.h b/src/llvm-project/llvm/include/llvm/Support/Signals.h
+index 44f5a750f..ccb429bdd 100644
+--- a/src/llvm-project/llvm/include/llvm/Support/Signals.h
++++ b/src/llvm-project/llvm/include/llvm/Support/Signals.h
+@@ -15,6 +15,7 @@
+ #define LLVM_SUPPORT_SIGNALS_H
+ 
+ #include <string>
++#include <cstdint>
+ 
+ namespace llvm {
+ class StringRef;

--- a/recipes-devtools/rust/rust-llvm_%.bbappend
+++ b/recipes-devtools/rust/rust-llvm_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0003-Add-necessary-include-file.patch;patchdir=../../.."
+


### PR DESCRIPTION
This adds a patch to add a missing include to allow rust to compile cleanly with newer versions of gcc.