### PR TITLE
Add polkit rule to allow ceres user to reboot

### DIFF
--- a/recipes-asteroid/asteroid-apps/asteroid-settings_git.bb
+++ b/recipes-asteroid/asteroid-apps/asteroid-settings_git.bb
@@ -10,5 +10,5 @@ require asteroid-app.inc
 
 inherit pkgconfig
 
-DEPENDS += "nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus"
-RDEPENDS:${PN} += "nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus qtmultimedia-qmlplugins libconnman-qt5-qmlplugins"
+DEPENDS += "nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus polkit-ceres-rule-reboot"
+RDEPENDS:${PN} += "nemo-qml-plugin-systemsettings nemo-qml-plugin-dbus qtmultimedia-qmlplugins libconnman-qt5-qmlplugins polkit-ceres-rule-reboot"

--- a/recipes-asteroid/asteroid-apps/files/30-org.freedesktop.login1.rules
+++ b/recipes-asteroid/asteroid-apps/files/30-org.freedesktop.login1.rules
@@ -1,0 +1,10 @@
+/* give user 'ceres' rights to reboot */
+
+polkit.addRule(function(action, subject) {
+  if ((action.id == "org.freedesktop.login1.set-reboot-parameter" ||
+       action.id == "org.freedesktop.login1.power-off-multiple-sessions" ||
+       action.id == "org.freedesktop.login1.reboot-multiple-sessions") &&
+        subject.user == "ceres") { 
+    return polkit.Result.YES;
+  }
+});


### PR DESCRIPTION
This adds a rule to allow the ceres user to reboot using D-Bus.  This is needed for an upcoming pull request for asteroid-settings to add the capability of rebooting to the bootloader.