### PR TITLE
tzdata: Install tzdata.zi.

### DIFF
--- a/recipes-extended/timezone/tzdata.bbappend
+++ b/recipes-extended/timezone/tzdata.bbappend
@@ -1,0 +1,8 @@
+do_install:prepend() {
+    install -d ${D}${datadir}/zoneinfo
+
+    (cd ${S}; oe_runmake tzdata.zi)
+    cp -pP "${S}/tzdata.zi" ${D}${datadir}/zoneinfo
+}
+
+FILES:tzdata-core += "${datadir}/zoneinfo/tzdata.zi"


### PR DESCRIPTION
This builds and installs tzdata.zi.

`timedated` attempts to load `tzdata.zi` which contains the linked regions as well. Currently this fails as this file doesn't exist. As a fallback it loads `zone1970.tab` instead. `zone1970.tab` does not contain the linked timezones. [^1]

This fixes an issue where linked timezones[^2] would not be shown in the ListTimezones DBus method.

[^1]: https://github.com/systemd/systemd/blob/581427bd658c585287a7f3db04eabdce922d9d0e/src/basic/time-util.c#L1443
[^2]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List