### PR TITLE
asteroid-launcher: Fix packaging issue for qemux86.

### DIFF
--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs_git.bb
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs_git.bb
@@ -17,7 +17,7 @@ do_install() {
     if [ -f ${WORKDIR}/qemu.conf ] ; then
         # Overwrite the default config.
         install -m 0644 ${WORKDIR}/qemu.conf ${D}/var/lib/environment/compositor/default.conf
-        install -m 0644 ${WORKDIR}/kms-qemu.conf ${D}/var/lib/environment/compositor/
+        install -m 0644 ${WORKDIR}/kms-qemu.json ${D}/var/lib/environment/compositor/
     fi
 
     install -d ${D}/usr/share/qt5/keymaps/


### PR DESCRIPTION
https://github.com/AsteroidOS/meta-asteroid/pull/133 split the asteroid-launcher recipe which resulted in a copying error where `kms-qemu.conf` was installed. But this file doesn't actually exist, instead `kms-qemu.json` should've been installed.

This rectifies this issue.