### PR TITLE
add the new session-restart service needed for settings restore to work

### DIFF
--- a/recipes-core/lcd-tools/lcd-tools.bb
+++ b/recipes-core/lcd-tools/lcd-tools.bb
@@ -16,6 +16,7 @@ do_install:append() {
     install -d ${D}/usr/lib/systemd/user/
     install -d ${D}/usr/lib/systemd/user/default.target.wants/
     ln -s /usr/lib/systemd/user/lcd-sync-time.timer ${D}/usr/lib/systemd/user/default.target.wants/lcd-sync-time.timer
+    ln -s /usr/lib/systemd/user/lcd-session-restart.service ${D}/usr/lib/systemd/user/default.target.wants/lcd-session-restart.service
 }
 
 FILES:${PN} += "/usr/lib/systemd/user/"


### PR DESCRIPTION
this is needed for https://github.com/AsteroidOS/lcd-tools/pull/7 to work