### PR TITLE
mce: Don't wake screen on palm event.

### DIFF
--- a/recipes-nemomobile/mce/mce/0007-powerkey-Also-suspend-on-palm-reports.patch
+++ b/recipes-nemomobile/mce/mce/0007-powerkey-Also-suspend-on-palm-reports.patch
@@ -1,8 +1,14 @@
-From fc86713d797c0defb781205b070fd17b438fb7f2 Mon Sep 17 00:00:00 2001
+From ab5b4f0bcf47ceda2bc66fd2d2f77e04287a9524 Mon Sep 17 00:00:00 2001
 From: MagneFire <dgriet@gmail.com>
 Date: Sun, 26 Dec 2021 19:40:13 +0100
 Subject: [PATCH] powerkey: Also suspend on palm reports.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
+%% original patch: 0007-powerkey-Also-suspend-on-palm-reports.patch
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
 ---
  event-input.c |   5 +++
  powerkey.c    | 102 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -25,7 +31,7 @@ index de0d19c..10c4894 100644
  EXIT:
      return flush;
 diff --git a/powerkey.c b/powerkey.c
-index e06e231..98297bf 100644
+index e06e231..9c73be7 100644
 --- a/powerkey.c
 +++ b/powerkey.c
 @@ -596,6 +596,7 @@ static void     pwrkey_setting_quit            (void);
@@ -75,7 +81,7 @@ index e06e231..98297bf 100644
 +        switch( ev->code ) {
 +        case KEY_SLEEP:
 +            if( ev->value == 1 ) {
-+                if( mce_lib_get_boot_tick() < press_limit ) {
++                if( mce_lib_get_boot_tick() < press_limit  || display_state_next == MCE_DISPLAY_OFF) {
 +                    /* Too soon after the previous powerkey
 +                     * release -> assume faulty hw sending
 +                     * bursts of presses */
@@ -152,5 +158,5 @@ index e06e231..98297bf 100644
          .datapipe = &ngfd_event_request_pipe,
          .input_cb = pwrkey_datapipe_ngfd_event_request_cb,
 -- 
-2.34.1
+2.41.0
 


### PR DESCRIPTION
The initial code was based on powerkey events.
While this works great, it also meant that the display would be turned on whenever on a palm event. This can occur when the touchscreen interface isn't suspended.

This fixes https://github.com/AsteroidOS/meta-smartwatch/issues/202.