### PR TITLE
brcm-patchram-plus: Remove default service.

### DIFF
--- a/recipes-android/brcm-patchram-plus/brcm-patchram-plus/patchram.service
+++ b/recipes-android/brcm-patchram-plus/brcm-patchram-plus/patchram.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Load firmware into broadcom bluetooth chip
-
-[Service]
-Type=simple
-ExecStart=/bin/echo This script should be device specific
-
-[Install]
-WantedBy=basic.target

--- a/recipes-android/brcm-patchram-plus/brcm-patchram-plus_git.bbappend
+++ b/recipes-android/brcm-patchram-plus/brcm-patchram-plus_git.bbappend
@@ -1,5 +1,4 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/brcm-patchram-plus:"
-SRC_URI:append= " file://patchram.service"
 LICENSE = "Apache-2.0"
 
 SRC_URI = "git://github.com/AsteroidOS/brcm-patchram-plus.git;protocol=https;branch=master"
@@ -9,9 +8,11 @@ SRCREV = "94fb127e614b19a9a95561b8c1a0716e2e1e6293"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 do_install:append() {
-    install -d ${D}/lib/systemd/system/multi-user.target.wants/
-    cp ${WORKDIR}/patchram.service ${D}/lib/systemd/system/
-    ln -s ../patchram.service ${D}/lib/systemd/system/multi-user.target.wants/patchram.service
+    if [ -f ${WORKDIR}/patchram.service ] ; then
+        install -d ${D}/lib/systemd/system/multi-user.target.wants/
+        cp ${WORKDIR}/patchram.service ${D}/lib/systemd/system/
+        ln -s ../patchram.service ${D}/lib/systemd/system/multi-user.target.wants/patchram.service
+    fi
 }
 
 FILES:${PN} += "/lib/systemd/system/"


### PR DESCRIPTION
The default service doesn't offer anything, it isn't useful on its own. Remove it such that build issues may become clear sooner.

This should fix an issue where the default patchram service is installed on the current nightlies.

This fixes: https://github.com/AsteroidOS/meta-smartwatch/issues/204