### PR TITLE
Add wifi-enabler recipe.

### DIFF
--- a/recipes-android/wifi-enabler/wifi-enabler/wifi-enabler.service
+++ b/recipes-android/wifi-enabler/wifi-enabler/wifi-enabler.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Load the WiFi firmware and enable driver
+
+[Service]
+Type=simple
+ExecStartPre=-/bin/sh -c "/bin/echo > /dev/wcnss_wlan"
+ExecStart=-/bin/sh -c "/bin/echo 1 > /sys/module/wlan/parameters/fwpath"
+
+[Install]
+WantedBy=basic.target
+

--- a/recipes-android/wifi-enabler/wifi-enabler_1.0.bb
+++ b/recipes-android/wifi-enabler/wifi-enabler_1.0.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "Load the WiFi firmware and enable driver"
+PR = "r0"
+SRC_URI = "file://wifi-enabler.service"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+S = "${WORKDIR}"
+
+inherit systemd
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "wifi-enabler.service"
+
+do_install() {
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/wifi-enabler.service ${D}${systemd_unitdir}/system/
+}


### PR DESCRIPTION
Some Qualcomm based watches need additional steps to enable WiFi. Ideally this service should be added to the Android init.rc but this does not appear to work since the commands are executed too soon in the boot process.

This provides a systemd service such that WiFi is enabled later in the boot process.