### PR TITLE
build ext4 images without ext4's metadata_csum feature

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -21,3 +21,5 @@ EXTRA_USERS_PARAMS = "groupadd system; \
 
 IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_ROOTFS_EXTRA_SPACE = "131072"
+
+EXTRA_IMAGECMD:ext4 += " -O^metadata_csum"


### PR DESCRIPTION
The "metadata_csum" feature changed in an incompatible fashion since the Linux 3.* kernel we use on `sparrow`, for example. This means that loop-mounting the ext4 on a modern Linux system and modifying it will result in a filesystem image that cannot be mounted by `sparrow`'s kernel.

The error message in question is:
```
[  156.079616](CPU:0-pid:235:dmesg) JBD2: Unrecognised features on journal
[  156.079639](CPU:0-pid:235:dmesg) EXT4-fs (mmcblk0p29): error loading journal
```

Marked as draft until I've actually built and tested this on `sparrow`. (I've tested on `beluga` and the `tune2fs -l` output looks okay...)