### PR TITLE
Remove pkg_postinst_ontarget rule for kernel images.

### DIFF
--- a/classes/abootimg.bbclass
+++ b/classes/abootimg.bbclass
@@ -27,26 +27,4 @@ do_deploy:append() {
     install -m 0644 ${B}/boot.img ${D}/${KERNEL_IMAGEDEST}
 }
 
-pkg_postinst_ontarget:${KERNEL_PACKAGE_NAME}-image:append () {
-    if [ ! -e /boot/boot.img ] ; then
-        # if the boot image is not available here something went wrong and we don't
-        # continue with anything that can be dangerous
-        exit 1
-    fi
-
-    BOOT_PARTITION_NAMES="LNX boot KERNEL"
-    for i in $BOOT_PARTITION_NAMES; do
-        path=$(find /dev -name "*$i*"|grep disk| head -n 1)
-        [ -n "$path" ] && break
-    done
-
-    if [ -z "$path" ] ; then
-        echo "Boot partition does not exist!"
-        exit 1
-    fi
-
-    echo "Flashing the new kernel /boot/boot.img to $path"
-    dd if=/boot/boot.img of=$path
-}
-
 FILES:${KERNEL_PACKAGE_NAME}-image += "/${KERNEL_IMAGEDEST}/boot.img"

--- a/classes/mkboot.bbclass
+++ b/classes/mkboot.bbclass
@@ -28,26 +28,4 @@ do_deploy:append() {
     install -m 0644 ${B}/boot.img ${D}/${KERNEL_IMAGEDEST}
 }
 
-pkg_postinst_ontarget:${KERNEL_PACKAGE_NAME}-image:append () {
-    if [ ! -e /boot/boot.img ] ; then
-        # if the boot image is not available here something went wrong and we don't
-        # continue with anything that can be dangerous
-        exit 1
-    fi
-
-    BOOT_PARTITION_NAMES="LNX boot KERNEL"
-    for i in $BOOT_PARTITION_NAMES; do
-        path=$(find /dev -name "*$i*"|grep disk| head -n 1)
-        [ -n "$path" ] && break
-    done
-
-    if [ -z "$path" ] ; then
-        echo "Boot partition does not exist!"
-        exit 1
-    fi
-
-    echo "Flashing the new kernel /boot/boot.img to $path"
-    dd if=/boot/boot.img of=$path
-}
-
 FILES:${KERNEL_PACKAGE_NAME}-image += "/${KERNEL_IMAGEDEST}/boot.img"

--- a/classes/mkbootimg.bbclass
+++ b/classes/mkbootimg.bbclass
@@ -25,26 +25,4 @@ do_deploy:append() {
     install -m 0644 ${B}/boot.img ${D}/${KERNEL_IMAGEDEST}
 }
 
-pkg_postinst_ontarget:${KERNEL_PACKAGE_NAME}-image:append () {
-    if [ ! -e /boot/boot.img ] ; then
-        # if the boot image is not available here something went wrong and we don't
-        # continue with anything that can be dangerous
-        exit 1
-    fi
-
-    BOOT_PARTITION_NAMES="LNX boot KERNEL"
-    for i in $BOOT_PARTITION_NAMES; do
-        path=$(find /dev -name "*$i*"|grep disk| head -n 1)
-        [ -n "$path" ] && break
-    done
-
-    if [ -z "$path" ] ; then
-        echo "Boot partition does not exist!"
-        exit 1
-    fi
-
-    echo "Flashing the new kernel /boot/boot.img to $path"
-    dd if=/boot/boot.img of=$path
-}
-
 FILES:${KERNEL_PACKAGE_NAME}-image += "/${KERNEL_IMAGEDEST}/boot.img"


### PR DESCRIPTION
This should fix the recent device bricks seen. The underlying problem was identified and described by @FlorentRevest, this is merely an attempt to translate his observations into a PR.

This means you will not be able to install a new kernel with `opkg` without also invoking fastboot. OTOH, that never worked reliably.

Some of the removed code was dodgy, and most likely caused https://github.com/AsteroidOS/meta-asteroid/issues/175

Further code should be removed but this will happen in a separate PR; this should fix the bricking issue and remove the kernel-update functionality, creating a consistently empty package for `linux-$machine-image` is less of a priority.

Fixes https://github.com/AsteroidOS/meta-asteroid/issues/175.