### PR TITLE
nfcd: Don't autostart service.

### DIFF
--- a/recipes-nemomobile/nfcd/nfcd_git.bb
+++ b/recipes-nemomobile/nfcd/nfcd_git.bb
@@ -20,6 +20,7 @@ RDEPENDS:${PN} += "nfcd-mce-plugin"
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "nfcd.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "disable"
 
 do_compile:append() {
     oe_runmake release


### PR DESCRIPTION
NFC seems to cause issues on multiple watches.
On `beluga` it causes for a screen flickering issues on the sides.
On `ray` it causes for random horizontal lines to appear as well as ghost touchscreen presses.

As there's currently little use of NFC disable the service from starting to workaround these issues.

This cause of this issue was first discovered by @argosphil.