### PR TITLE
enable restart-on-failure for bluetooth service

### DIFF
--- a/recipes-connectivity/bluez5/bluez5/bluetooth.service
+++ b/recipes-connectivity/bluez5/bluez5/bluetooth.service
@@ -9,7 +9,7 @@ BusName=org.bluez
 ExecStart=/usr/libexec/bluetooth/bluetoothd -E --noplugin=sap
 NotifyAccess=main
 #WatchdogSec=10
-#Restart=on-failure
+Restart=on-failure
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
 LimitNPROC=1
 


### PR DESCRIPTION
Some watches suffer from occasional bluez crashes for various reasons, likely due to issues with the vendor bluetooth blobs. Bluetooth sync is important for the asteroid experience, this change enables restart on failure so that phone synchronisation is a bit more stable.