### PR TITLE
Fix 276

### DIFF
--- a/recipes-core/libxcrypt/libxcrypt_%.bbappend
+++ b/recipes-core/libxcrypt/libxcrypt_%.bbappend
@@ -1,0 +1,1 @@
+SRCREV = "f531a36aa916a22ef2ce7d270ba381e264250cbf"

--- a/recipes-qt/qt5/qtbase-native_git.bbappend
+++ b/recipes-qt/qt5/qtbase-native_git.bbappend
@@ -1,2 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/qtbase:"
+SRC_URI += "file://0001-xkb-fix-build-with-libxkbcommon-1.6.0-and-later.patch"
+
 PACKAGECONFIG:append = " gui "
 PACKAGECONFIG_CONFARGS:append = " -make tools "

--- a/recipes-qt/qt5/qtbase/0001-xkb-fix-build-with-libxkbcommon-1.6.0-and-later.patch
+++ b/recipes-qt/qt5/qtbase/0001-xkb-fix-build-with-libxkbcommon-1.6.0-and-later.patch
@@ -1,0 +1,43 @@
+From f061059a5361ae074f46a67de79e00535bbb9d67 Mon Sep 17 00:00:00 2001
+From: Liang Qi <liang.qi@qt.io>
+Date: Tue, 10 Oct 2023 14:08:48 +0200
+Subject: [PATCH] xkb: fix build with libxkbcommon 1.6.0 and later
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+A few XKB_KEY_dead_* defines got removed from 1.6.0. See also
+https://github.com/xkbcommon/libxkbcommon/blob/6073565903488cb5b9a8d37fdc4a7c2f9d7ad04d/NEWS#L9-L14
+https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/merge_requests/70/diffs?commit_id=cb44799b72f611eb4c9d7cc185bc3b09e070be08
+
+Pick-to: 6.6 6.5 6.2 5.15
+Fixes: QTBUG-117950
+Change-Id: I55861868f2bb29c553d68365fa9b9b6ed01c9aea
+Reviewed-by: Tor Arne Vestbø <tor.arne.vestbo@qt.io>
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ src/platformsupport/input/xkbcommon/qxkbcommon.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/platformsupport/input/xkbcommon/qxkbcommon.cpp b/src/platformsupport/input/xkbcommon/qxkbcommon.cpp
+index 9aa8f10c57..b6f480684b 100644
+--- a/src/platformsupport/input/xkbcommon/qxkbcommon.cpp
++++ b/src/platformsupport/input/xkbcommon/qxkbcommon.cpp
+@@ -273,10 +273,14 @@ static constexpr const auto KeyTbl = qMakeArray(
+         Xkb2Qt<XKB_KEY_dead_small_schwa,        Qt::Key_Dead_Small_Schwa>,
+         Xkb2Qt<XKB_KEY_dead_capital_schwa,      Qt::Key_Dead_Capital_Schwa>,
+         Xkb2Qt<XKB_KEY_dead_greek,              Qt::Key_Dead_Greek>,
++/* The following four XKB_KEY_dead keys got removed in libxkbcommon 1.6.0
++   The define check is kind of version check here. */
++#ifdef XKB_KEY_dead_lowline
+         Xkb2Qt<XKB_KEY_dead_lowline,            Qt::Key_Dead_Lowline>,
+         Xkb2Qt<XKB_KEY_dead_aboveverticalline,  Qt::Key_Dead_Aboveverticalline>,
+         Xkb2Qt<XKB_KEY_dead_belowverticalline,  Qt::Key_Dead_Belowverticalline>,
+         Xkb2Qt<XKB_KEY_dead_longsolidusoverlay, Qt::Key_Dead_Longsolidusoverlay>,
++#endif
+
+         // Special keys from X.org - This include multimedia keys,
+         // wireless/bluetooth/uwb keys, special launcher keys, etc.
+--
+2.42.1
+


### PR DESCRIPTION
This fixes https://github.com/AsteroidOS/asteroid/issues/276 by adding some fixes identified by @MagneFire.  We had originally hoped to be able to migrate to mickledore first, but that is proving more difficult than anticipated -- this fix works for both `kirkstone` and `mickledore`.