### PR TITLE
Add qrtr recipe

### DIFF
--- a/recipes-core/qrtr/qrtr/0001-Makefile-Allow-for-prefix-override.patch
+++ b/recipes-core/qrtr/qrtr/0001-Makefile-Allow-for-prefix-override.patch
@@ -1,0 +1,29 @@
+From 98d9ee0dc9b93f84fb4739d9a7bc3c7e57cc3a58 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Darrel=20Gri=C3=ABt?= <dgriet@gmail.com>
+Date: Wed, 8 Nov 2023 21:43:24 +0100
+Subject: [PATCH] Makefile: Allow for prefix override
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index bd6c1cd..7273a23 100644
+--- a/Makefile
++++ b/Makefile
+@@ -4,7 +4,7 @@ proj-minor := 0
+ proj-version := $(proj-major).$(proj-minor)
+ 
+ CFLAGS += -Wall -g
+-prefix = /usr/local
++prefix ?= /usr/local
+ 
+ bindir := $(prefix)/bin
+ libdir := $(prefix)/lib
+-- 
+2.42.1
+

--- a/recipes-core/qrtr/qrtr_git.bb
+++ b/recipes-core/qrtr/qrtr_git.bb
@@ -1,0 +1,24 @@
+SUMMARY = " Userspace reference for net/qrtr in the Linux kernel."
+HOMEPAGE = "https://github.com/andersson/qrtr"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=15329706fbfcb5fc5edcc1bc7c139da5"
+
+SRC_URI = "git://github.com/andersson/qrtr.git;protocol=https;branch=master \
+           file://0001-Makefile-Allow-for-prefix-override.patch \
+           "
+SRCREV = "d0d471c96e7d112fac6f48bd11f9e8ce209c04d2"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+DEPENDS += "glib-2.0 systemd"
+
+inherit pkgconfig
+inherit systemd
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "qrtr-ns.service"
+
+do_install() {
+    oe_runmake install DESTDIR=${D} prefix=${prefix} servicedir=${systemd_system_unitdir}
+}


### PR DESCRIPTION
Adds the userspace Qualcomm IPC router needed for booting the modem on `hoki`.