### PR TITLE
Add sparse image generation support

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -23,3 +23,14 @@ IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_ROOTFS_EXTRA_SPACE = "131072"
 
 EXTRA_IMAGECMD:ext4 += " -O^metadata_csum"
+
+DEPENDS:append = " ${@oe.utils.conditional('GENERATE_SPARSE_IMAGE', 'true', 'android-simg2img-native', '', d)} "
+
+generate_sparse_image() {
+    if [ -n "${GENERATE_SPARSE_IMAGE}" ]; then
+        img2simg "${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.ext4" "${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.simg"
+        ln -s "${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.simg" "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.simg"
+    fi
+}
+
+IMAGE_POSTPROCESS_COMMAND:append = " generate_sparse_image ; "

--- a/recipes-devtools/android-simg2img/android-simg2img_git.bb
+++ b/recipes-devtools/android-simg2img/android-simg2img_git.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Tool to convert Android sparse images"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://img2simg.cpp;beginline=1;endline=15;md5=69dd3a3cbb50842da4c61d01ee32f421"
+
+SRC_URI = "git://github.com/AsteroidOS/android-simg2img.git;protocol=https;branch=master"
+SRCREV = "25866381ea14caffec1d069d4226793b2d28a6a2"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 755 append2simg ${D}${bindir}/
+    install -m 755 img2simg ${D}${bindir}/
+    install -m 755 simg2img ${D}${bindir}/
+    install -m 755 simg2simg ${D}${bindir}/
+    install -m 755 simg_dump.py ${D}${bindir}/
+}
+
+DEPENDS += "zlib"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Previously this was only available for `tetra` since the bootloader didn't support specific chunk types.

But it seems that this is also needed for `pike` when using a real install. Hence import the recipe in `meta-asteroid` and use a global variable to enable sparse image generation.

Other relevant PR: https://github.com/AsteroidOS/meta-smartwatch/pull/238