### PR TITLE
Remove unconditional hybris dependencies

### DIFF
--- a/conf/machine/include/hybris-watch.inc
+++ b/conf/machine/include/hybris-watch.inc
@@ -1,4 +1,5 @@
 MACHINE_FEATURES = "alsa bluetooth usbgadget usbhost ext2"
+MACHINEOVERRIDES =. "hybris-machine:"
 
 SERIAL_CONSOLE = "115200 ttyHSL0"
 

--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher-configs/default.conf
@@ -1,5 +1,4 @@
-EGL_PLATFORM=hwcomposer
-QT_QPA_PLATFORM=hwcomposer
-LIPSTICK_OPTIONS="-plugin evdevtouch:/dev/input/event0"
+QT_QPA_PLATFORM=eglfs
+QT_QPA_EGLFS_INTEGRATION=eglfs_kms
 QT_IM_MODULE=qtvirtualkeyboard
-QT_GSTREAMER_CAMERABIN_SRC=droidcamsrc
+LIPSTICK_OPTIONS="-plugin evdevtouch:/dev/input/event0"

--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher/asteroid-launcher-precondition
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher/asteroid-launcher-precondition
@@ -1,4 +1,3 @@
 #! /bin/sh
-if [ -f /usr/lib/systemd/user/android-boot-completed.service ]; then
-    while [ ! -f /dev/.coldboot_done ] ; do sleep 1; done
-fi
+# This file is a placeholder to be replaced by machine-specific preconditions
+exit 0

--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher/asteroid-launcher-precondition-hybris
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher/asteroid-launcher-precondition-hybris
@@ -1,0 +1,4 @@
+#! /bin/sh
+if [ -f /usr/lib/systemd/user/android-boot-completed.service ]; then
+    while [ ! -f /dev/.coldboot_done ] ; do sleep 1; done
+fi

--- a/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bb
+++ b/recipes-asteroid/asteroid-launcher/asteroid-launcher_git.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://src/qml/MainScreen.qml;beginline=1;endline=29;md5=3d2
 SRC_URI = "git://github.com/AsteroidOS/asteroid-launcher.git;protocol=https;branch=master \
     file://asteroid-launcher.service \
     file://asteroid-launcher-precondition"
+SRC_URI:append:hybris-machine = " file://asteroid-launcher-precondition-hybris "
 SRCREV = "${AUTOREV}"
 PR = "r1"
 PV = "+git${SRCPV}"
@@ -29,4 +30,9 @@ do_install:append() {
     if [ ! -f ${D}/usr/lib/systemd/user/default.target.wants/asteroid-launcher.service ]; then
         ln -s /usr/lib/systemd/user/asteroid-launcher.service ${D}/usr/lib/systemd/user/default.target.wants/asteroid-launcher.service
     fi
+}
+
+do_install:apppend:hybris-machine() {
+    # On hybris machines, the launcher must run only after Android has started
+    install -m 0755 ${WORKDIR}/asteroid-launcher-precondition-hybris ${D}/usr/bin/asteroid-launcher-precondition
 }

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,16 +1,18 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-SRC_URI:append = " file://50-video.rules \
+SRC_URI:append:hybris-machine = " file://50-video.rules \
                   file://65-android.rules"
 
 do_install:append() {
-    # Setup udev rules for the rights of Android and graphic cards specific devices
-    install -m 0644 ${WORKDIR}/50-video.rules ${D}${sysconfdir}/udev/rules.d/50-video.rules
-    install -m 0644 ${WORKDIR}/65-android.rules ${D}${sysconfdir}/udev/rules.d/65-android.rules
-
     # Enables auto-login for ceres
     install -d ${D}/var/lib/systemd/linger
     touch ${D}/var/lib/systemd/linger/ceres
     sed -i "s@agetty --noclear @agetty --autologin ceres @" ${D}/lib/systemd/system/getty@.service
+}
+
+do_install:append:hybris-machine() {
+    # Setup udev rules for the rights of Android and graphic cards specific devices
+    install -m 0644 ${WORKDIR}/50-video.rules ${D}${sysconfdir}/udev/rules.d/50-video.rules
+    install -m 0644 ${WORKDIR}/65-android.rules ${D}${sysconfdir}/udev/rules.d/65-android.rules
 }
 
 PACKAGECONFIG:append = " pam"

--- a/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -1,5 +1,5 @@
-RDEPENDS:pulseaudio-server:append = " pulseaudio-modules-nemo pulseaudio-module-dbus-protocol pulseaudio-module-match pulseaudio-module-switch-on-connect pulseaudio-module-bluetooth-discover pulseaudio-module-bluetooth-policy pulseaudio-module-bluez5-discover pulseaudio-module-bluez5-device pulseaudio-modules-droid "
-RDEPENDS:pulseaudio-server:remove:qemux86 = " pulseaudio-modules-droid "
+RDEPENDS:pulseaudio-server:append = " pulseaudio-modules-nemo pulseaudio-module-dbus-protocol pulseaudio-module-match pulseaudio-module-switch-on-connect pulseaudio-module-bluetooth-discover pulseaudio-module-bluetooth-policy pulseaudio-module-bluez5-discover pulseaudio-module-bluez5-device "
+RDEPENDS:pulseaudio-server:append:hybris-machine = " pulseaudio-modules-droid "
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/pulseaudio:"
 SRC_URI += "file://1002-build-Install-pulsecore-headers.patch \

--- a/recipes-nemomobile/sensorfw/sensorfw.inc
+++ b/recipes-nemomobile/sensorfw/sensorfw.inc
@@ -27,14 +27,20 @@ do_configure:prepend() {
     sed "s=@LIB@=lib/=g" ../git/sensord-qt5.pc.in > ../git/sensord-qt5.pc
     sed -i 's/$$\[QT_INSTALL_LIBS\]/\/usr\/lib/g' ../git/core/core.pro
     sed -i '/include( doc\/doc.pri )/d' ../git/sensorfw.pro
+}
+
+do_configure:prepend:hybris-machine() {
     sed -i 's:-L/usr/lib ::' ../git/core/hybris.pro
 }
 
 do_install:append() {
     install -d ${D}/etc/sensorfw/ ${D}/lib/systemd/system/multi-user.target.wants/
-    cp ${S}/config/sensord-hybris.conf ${D}/etc/sensorfw/primaryuse.conf
     cp ../sensorfwd.service ${D}/lib/systemd/system/sensorfwd.service
     ln -s ../sensorfwd.service ${D}/lib/systemd/system/multi-user.target.wants/
+}
+
+do_install:append:hybris-machine() {
+    cp ${S}/config/sensord-hybris.conf ${D}/etc/sensorfw/primaryuse.conf
 }
 
 DEPENDS += "qtbase"

--- a/recipes-qt/qt5/qtbase_git.bbappend
+++ b/recipes-qt/qt5/qtbase_git.bbappend
@@ -1,12 +1,12 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/qtbase:"
 SRC_URI += " file://0002-qplatforminputcontextfactory-Use-qtvirtualkeyboard-b.patch"
 
-# Remove dependencies to mesa
-PACKAGECONFIG:remove = "tests"
-PACKAGECONFIG:remove = "widgets"
-PACKAGECONFIG:remove = "gl"
-PACKAGECONFIG:append = "gles2 mtdev sql-sqlite glib fontconfig gif"
-PACKAGECONFIG_GL:append:qemux86 = " eglfs gbm kms"
+PACKAGECONFIG:append = " gles2 mtdev sql-sqlite glib fontconfig gif "
+PACKAGECONFIG_GL:append = " eglfs gbm kms "
+
+# Remove dependencies to mesa on hybris-based machines
+PACKAGECONFIG:remove:hybris-machine = " tests widgets gl "
+PACKAGECONFIG_GL:remove:hybris-machine = " eglfs gbm kms "
 
 QT_CONFIG_FLAGS += "--no-feature-getentropy"
 

--- a/recipes-qt/qt5/qtscenegraph-adaptation_git.bb
+++ b/recipes-qt/qt5/qtscenegraph-adaptation_git.bb
@@ -9,7 +9,8 @@ LIC_FILES_CHKSUM = " \
 PV = "5.8.0+git${SRCPV}"
 SRCREV = "13394b94c6c406fafdd7a95edc12938efeb4d66a"
 
-DEPENDS = "qtbase libhybris qtwayland virtual/android-headers qtdeclarative"
+DEPENDS = "qtbase qtwayland qtdeclarative "
+DEPENDS:append:hybris-machine = "libhybris virtual/android-headers"
 
 SRC_URI = "git://github.com/sailfishos/qtscenegraph-adaptation.git;protocol=https;branch=master \
         file://0001-customcontext-Adapt-for-Qt-5.8.patch \
@@ -20,7 +21,8 @@ S = "${WORKDIR}/git"
 
 inherit qmake5
 
-EXTRA_QMAKEVARS_PRE += "CONFIG+=surfaceformat CONFIG+=programbinary CONFIG+=hybristexture"
+EXTRA_QMAKEVARS_PRE += "CONFIG+=surfaceformat CONFIG+=programbinary"
+EXTRA_QMAKEVARS_PRE:hybris-machine += "CONFIG+=hybristexture"
 
 FILES:${PN} += "${OE_QMAKE_PATH_PLUGINS}"
 


### PR DESCRIPTION
Some components in AsteroidOS unconditionally depend on libhybris, and many default configs assume a hybris-based device. This PR breaks out these dependencies, paving the way for easily supporting devices running mainline without Android drivers.

Changes to meta-smartwatch are not required. 

I have tested these changes on catfish and they seem to work fine there, but more testing on other watches is appreciated, given how broad the changes are.