### PR TITLE
Add missing architectures to PACKAGE_FEED_ARCHS

### DIFF
--- a/conf/distro/asteroid.conf
+++ b/conf/distro/asteroid.conf
@@ -38,6 +38,6 @@ FILESYSTEM_PERMS_TABLES = "files/fs-perms.txt files/asteroidos-fs-perms.txt"
 
 PACKAGE_FEED_URIS = "https://release.asteroidos.org/nightlies/"
 PACKAGE_FEED_BASE_PATHS = "ipk"
-PACKAGE_FEED_ARCHS = "all anthias armv7vehf-neon bass core2-32 dory lenok qemux86 sparrow sprat sturgeon swift tetra wren"
+PACKAGE_FEED_ARCHS = "all anthias armv7vehf-neon bass beluga catfish core2-32 dory firefish harmony hoki inharmony koi lenok minnow mooneye narwhal nemo pike qemux86 ray skipjack smelt sparrow sprat sturgeon swift tetra triggerfish wren"
 
 SKIP_META_GNOME_SANITY_CHECK = "1"


### PR DESCRIPTION
This adds several missing archs to the PACKAGE_FEED_ARCHS variable.  The problem was noted in Matrix chat by user @asozcan who was attempting to update a ray watch using opkg and noted that no ray packages were being downloaded.  Confirming this, it was also noticed that a number of other architectures were also missing.  The ones that were added in this patch are:  beluga catfish firefish harmony hoki inharmony koi minnow mooneye narwhal nemo pike ray skipjack smelt triggerfish

Fixes #191