### PR TITLE
Fix pseudo-native to compile cleanly with gcc14

### DIFF
--- a/recipes-devtools/pseudo/pseudo/0001-configure-Prune-PIE-flags.patch
+++ b/recipes-devtools/pseudo/pseudo/0001-configure-Prune-PIE-flags.patch
@@ -1,0 +1,40 @@
+From b4bac8ba09d3d3aba36817b23399da18ec759b9e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 17 Feb 2016 07:36:34 +0000
+Subject: [PATCH] configure: Prune PIE flags
+
+LDFLAGS are not taken from environment and CFLAGS is used for LDFLAGS
+however when using security options -fpie and -pie options are coming
+as part of ARCH_FLAGS and they get into LDFLAGS of shared objects as
+well so we end up with conflicting options -shared -pie, which gold
+rejects outright and bfd linker lets the one appearning last in cmdline
+take effect. This create quite a unpleasant situation in OE when
+security flags are enabled and gold or not-gold options are used
+it errors out but errors are not same.
+
+Anyway, with this patch we filter pie options from ARCH_FLAGS
+ouright and take control of generating PIC objects
+
+Helps with errors like
+
+| /mnt/oe/build/tmp-glibc/sysroots/x86_64-linux/usr/libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/5.3.0/ld: pseudo_client.o: relocation R_X86_64_PC32 against symbol `pseudo_util_debug_flags' can not be used when making a shared object; recompile with -fPIC
+| /mnt/oe/build/tmp-glibc/sysroots/x86_64-linux/usr/libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/5.3.0/ld: final link failed: Bad value
+| collect2: error: ld returned 1 exit status
+| make: *** [lib/pseudo/lib64/libpseudo.so] Error 1
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+---
+ configure | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configure b/configure
+index 39b5fbe..d596a35 100755
+--- a/configure
++++ b/configure
+@@ -349,3 +349,5 @@ sed -e '
+   s,@ARCH@,'"$opt_arch"',g
+   s,@BITS@,'"$opt_bits"',g
+ ' < Makefile.in > Makefile
++
++sed -i -e 's/\-[f]*pie//g' Makefile

--- a/recipes-devtools/pseudo/pseudo/0005-Use-raw-strings-for-regex-with-backslash-char-pair.patch
+++ b/recipes-devtools/pseudo/pseudo/0005-Use-raw-strings-for-regex-with-backslash-char-pair.patch
@@ -1,0 +1,54 @@
+From 1874d626620dec3c595b21b1f319a6f2d0a5d9c4 Mon Sep 17 00:00:00 2001
+From: Ed Beroset <beroset@ieee.org>
+Date: Sat, 25 May 2024 12:03:32 -0400
+Subject: [PATCH] Use raw strings for regex with backslash-char pair
+
+As per
+https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes
+this removes some SyntaxWarnings that occurred because of using
+backslash-char pairs in regex strings.  This simply changes those
+strings to be raw strings instead.
+
+Signed-off-by: Ed Beroset <beroset@ieee.org>
+---
+ makewrappers | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/makewrappers b/makewrappers
+index cf5ad60..1e80e30 100755
+--- a/makewrappers
++++ b/makewrappers
+@@ -127,7 +127,7 @@ class Argument:
+             self.vararg = False
+ 
+         # try for a function pointer
+-        match = re.match('(.*)\(\*([a-zA-Z0-9$_]*)\)\((.*)\)', text)
++        match = re.match(r'(.*)\(\*([a-zA-Z0-9$_]*)\)\((.*)\)', text)
+         if match:
+             self.function_pointer = True
+             self.args = match.group(3)
+@@ -135,7 +135,7 @@ class Argument:
+             self.name = match.group(2).rstrip()
+         else:
+             # plain declaration
+-            match = re.match('(.*[ *])\(?\*?([a-zA-Z0-9$_]*)\)?', text)
++            match = re.match(r'(.*[ *])\(?\*?([a-zA-Z0-9$_]*)\)?', text)
+             # there may not be a match, say in the special case
+             # where an arg is '...'
+             if match:
+@@ -237,13 +237,13 @@ class Function:
+         self.date = datetime.date.today().year
+     
+         function, comments = line.split(';')
+-        comment = re.search('/\* *(.*) *\*/', comments)
++        comment = re.search(r'/\* *(.*) *\*/', comments)
+         if comment:
+             self.comments = comment.group(1)
+         else:
+             self.comments = None
+     
+-        bits = re.match('([^(]*)\((.*)\)', function)
++        bits = re.match(r'([^(]*)\((.*)\)', function)
+         type_and_name = Argument(bits.group(1))
+         self.type, self.name = type_and_name.type, type_and_name.name
+         # convenient to have this declared here so we can use its .decl later

--- a/recipes-devtools/pseudo/pseudo/0006-Correct-the-order-of-arguments-to-calloc.patch
+++ b/recipes-devtools/pseudo/pseudo/0006-Correct-the-order-of-arguments-to-calloc.patch
@@ -1,0 +1,54 @@
+From 50801e2451ec0020fdac4eb0f6e2643ed9b7ff97 Mon Sep 17 00:00:00 2001
+From: Ed Beroset <beroset@ieee.org>
+Date: Sat, 25 May 2024 12:08:41 -0400
+Subject: [PATCH] Correct the order of arguments to calloc
+
+The prototype for calloc is this:
+void *calloc(size_t nmemb, size_t size);
+
+This change corrects several calls that incorrectly used the sizeof()
+operator for the first argument and 1 as the second argument.  Reversing
+those arguments clarifies meaning and also avoids a
+-Wcalloc-transposed-args warning that is emitted with gcc 14.
+
+Signed-off-by: Ed Beroset <beroset@ieee.org>
+---
+ pseudo_db.c | 4 ++--
+ pseudolog.c | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/pseudo_db.c b/pseudo_db.c
+index 14bafcb..a269f69 100644
+--- a/pseudo_db.c
++++ b/pseudo_db.c
+@@ -783,7 +783,7 @@ pdb_log_traits(pseudo_query_t *traits) {
+ 		pseudo_diag("%s: database error.\n", __func__);
+ 		return 1;
+ 	}
+-	e = calloc(sizeof(*e), 1);
++	e = calloc(1, sizeof(*e));
+ 	if (!e) {
+ 		pseudo_diag("can't allocate space for log entry.");
+ 		return 1;
+@@ -1376,7 +1376,7 @@ pdb_history_entry(log_history h) {
+ 		dberr(log_db, "statement failed");
+ 		return 0;
+ 	}
+-	l = calloc(sizeof(log_entry), 1);
++	l = calloc(1, sizeof(log_entry));
+ 	if (!l) {
+ 		pseudo_diag("couldn't allocate log entry.\n");
+ 		return 0;
+diff --git a/pseudolog.c b/pseudolog.c
+index 3ec4b77..74fcf99 100644
+--- a/pseudolog.c
++++ b/pseudolog.c
+@@ -374,7 +374,7 @@ plog_trait(int opt, char *string) {
+ 		pseudo_diag("invalid empty string for -%c\n", opt);
+ 		return 0;
+ 	}
+-	new_trait = calloc(sizeof(*new_trait), 1);
++	new_trait = calloc(1, sizeof(*new_trait));
+ 	if (!new_trait) {
+ 		pseudo_diag("Couldn't allocate requested trait (for -%c %s)\n",
+ 			opt, string ? string : "<nil>");

--- a/recipes-devtools/pseudo/pseudo/0007-Add-correct-preprocessor-arg-to-fix-error.patch
+++ b/recipes-devtools/pseudo/pseudo/0007-Add-correct-preprocessor-arg-to-fix-error.patch
@@ -1,0 +1,37 @@
+From ec5f69e0c936299798795d67303d3e753ea664d8 Mon Sep 17 00:00:00 2001
+From: Ed Beroset <beroset@ieee.org>
+Date: Sat, 25 May 2024 12:13:35 -0400
+Subject: [PATCH] Add correct preprocessor arg to fix error
+
+In gcc 14, several things that had only been warning are now reported as
+errors.  This includes -Werror=implicit-function-declaration as
+documented here: https://gcc.gnu.org/gcc-14/porting_to.html#warnings-as-errors
+
+In this code, the problem was that strptime() was not being declared due
+to a missing preprocessor macro.  This addresses that problem by
+defining two different macro definitions instead of the one that had been
+there, with the code comment amended to note this change.
+
+Signed-off-by: Ed Beroset <beroset@ieee.org>
+---
+ pseudolog.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/pseudolog.c b/pseudolog.c
+index 74fcf99..88920e8 100644
+--- a/pseudolog.c
++++ b/pseudolog.c
+@@ -6,9 +6,10 @@
+  * SPDX-License-Identifier: LGPL-2.1-only
+  *
+  */
+-/* We need _XOPEN_SOURCE for strptime(), but if we define that,
+- * we then don't get S_IFSOCK... _GNU_SOURCE turns on everything. */
+-#define _DEFAULT_SOURCE
++/* We need _XOPEN_SOURCE for strptime(), 
++ * and _BSD_SOURCE for S_IFSOCK... */
++#define _XOPEN_SOURCE
++#define _BSD_SOURCE 
+ 
+ #include <ctype.h>
+ #include <limits.h>

--- a/recipes-devtools/pseudo/pseudo/older-glibc-symbols.patch
+++ b/recipes-devtools/pseudo/pseudo/older-glibc-symbols.patch
@@ -1,0 +1,62 @@
+From 73c6c2e607f26c8a8db142e9971e1abac45fbd15 Mon Sep 17 00:00:00 2001
+From: Richard Purdie <richard.purdie@linuxfoundation.org>
+Date: Tue, 17 Aug 2021 15:21:26 +0100
+Subject: [PATCH] pseudo: Fix to work with glibc 2.34 systems
+
+If we link against a newer glibc 2.34 and then try and our LD_PRELOAD is run against a
+binary on a host with an older libc, we see symbol errors since in glibc 2.34, pthread
+and dl are merged into libc itself.
+
+We need to use the older form of linking so use glibc binaries from an older release
+to force this. We only use minimal symbols from these anyway.
+
+pthread_atfork is problematic, particularly on arm so use the internal glibc routine
+it maps too. This was always present in the main libc from 2.3.2 onwards.
+
+Yes this is horrible. Better solutions welcome.
+
+There is more info in the bug: [YOCTO #14521]
+
+Upstream-Status: Inappropriate [this patch is native and nativesdk]
+Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
+
+Tweak library search order, make prebuilt lib ahead of recipe lib
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+---
+ Makefile.in       | 2 +-
+ pseudo_wrappers.c | 5 ++++-
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 48fdbd2..02cb537 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -120,7 +120,7 @@ $(PSEUDODB): pseudodb.o $(SHOBJS) $(DBOBJS) pseudo_ipc.o | $(BIN)
+ libpseudo: $(LIBPSEUDO)
+ 
+ $(LIBPSEUDO): $(WRAPOBJS) pseudo_client.o pseudo_ipc.o $(SHOBJS) | $(LIB)
+-	$(CC) $(CFLAGS) $(CFLAGS_PSEUDO) -shared -o $(LIBPSEUDO) \
++	$(CC) $(CFLAGS)  -Lprebuilt/$(shell uname -m)-linux/lib/ $(CFLAGS_PSEUDO) -shared -o $(LIBPSEUDO) \
+ 		pseudo_client.o pseudo_ipc.o \
+ 		$(WRAPOBJS) $(SHOBJS) $(LDFLAGS) $(CLIENT_LDFLAGS)
+ 
+diff --git a/pseudo_wrappers.c b/pseudo_wrappers.c
+index 0d1cec6..a85d6d4 100644
+--- a/pseudo_wrappers.c
++++ b/pseudo_wrappers.c
+@@ -109,10 +109,13 @@ static void libpseudo_atfork_child(void)
+ 	pseudo_mutex_holder = 0;
+ }
+ 
++extern void *__dso_handle;
++extern int __register_atfork (void (*) (void), void (*) (void), void (*) (void), void *);
++
+ static void
+ _libpseudo_init(void) {
+ 	if (!_libpseudo_initted)
+-		pthread_atfork(NULL, NULL, libpseudo_atfork_child);
++		__register_atfork (NULL, NULL, libpseudo_atfork_child, &__dso_handle == NULL ? NULL : __dso_handle);
+ 
+ 	pseudo_getlock();
+ 	pseudo_antimagic();

--- a/recipes-devtools/pseudo/pseudo_%.bbappend
+++ b/recipes-devtools/pseudo/pseudo_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0005-Use-raw-strings-for-regex-with-backslash-char-pair.patch \
+            file://0006-Correct-the-order-of-arguments-to-calloc.patch \
+            file://0007-Add-correct-preprocessor-arg-to-fix-error.patch \
+"
+


### PR DESCRIPTION
This applies some fixes to allow gcc14 to cleanly compile pseudo-native. It partially addresses [#287](https://github.com/AsteroidOS/asteroid/issues/287).