### PR TITLE
Add ceres user to input group

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -17,7 +17,7 @@ EXTRA_USERS_PARAMS = "groupadd system; \
                       groupadd gps; \
                       groupadd datetime; \
                       groupadd -f -g 1024 mtp; \
-                      useradd -p '' -G 'audio,video,system,wheel,gps,sailfish-datetime,datetime,mtp,users' ceres"
+                      useradd -p '' -G 'audio,video,system,wheel,gps,sailfish-datetime,datetime,mtp,users,input' ceres"
 
 IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_ROOTFS_EXTRA_SPACE = "131072"


### PR DESCRIPTION
This fixes https://github.com/AsteroidOS/asteroid/issues/139 and partially addresses https://github.com/AsteroidOS/asteroid/issues/110 by adding the ceres user to the "input" group.  This allows the mouse to work for both the qemux86 and Raspberry Pi builds.  Watch builds are unaffected.