### PR TITLE
swclock-offset: Bump SRCREV

### DIFF
--- a/recipes-android/swclock-offset/swclock-offset_git.bb
+++ b/recipes-android/swclock-offset/swclock-offset_git.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1b72c0c4f0ef6806f2bc255ef3ca61c1"
 
 SRC_URI = "git://gitlab.com/postmarketOS/swclock-offset.git;protocol=https;branch=master"
-SRCREV = "0.2.2"
+SRCREV = "6a4e4dcee814c7cfc22e0f69a6dc510086cb7abf"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
@@ -15,9 +15,12 @@ do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 
 do_install() {
-    oe_runmake install DESTDIR=${D} PREFIX=${prefix}
+    oe_runmake install DESTDIR=${D}
 
-    oe_runmake install_systemd DESTDIR=${D}/${prefix}
+    # Remove OpenRC init files
+    for d in swclock-offset-boot swclock-offset-shutdown; do
+        rm ${D}/${sysconfdir}/init.d/$d
+    done
 }
 
 inherit systemd


### PR DESCRIPTION
Upstream now also uses /usr. So we don't need to manually state that it needs to be installed there.
Additionally OpenRC and systemd services files are always installed, so we need to remove the OpenRC files manually to fix packaging issues.

This adjusts the recipe to work with these MRs:
- https://gitlab.com/postmarketOS/swclock-offset/-/merge_requests/4
- https://gitlab.com/postmarketOS/swclock-offset/-/merge_requests/5