### PR TITLE
usb-moded: Create flag file /etc/usb-debugging-enabled

### DIFF
--- a/recipes-nemomobile/usb-moded/usb-moded_git.bb
+++ b/recipes-nemomobile/usb-moded/usb-moded_git.bb
@@ -74,7 +74,7 @@ do_install:append() {
     install -d ${D}/var/lib/misc/
     touch ${D}/var/lib/misc/udhcpd.leases
 
-    touch ${D}/var/usb-debugging-enabled
+    touch ${D}/etc/usb-debugging-enabled
 }
 
 FILES:${PN} += " ${systemd_system_unitdir} /usr/share/dbus-1/services/ /var/lib/misc/udhcpd.leases"


### PR DESCRIPTION
Upstream changed the ConditionPathExists to use a different path as it's more suitable for build time files. [^1]

Adjust the recipe to create the file on this location similarly to how upstream achieves this. [^2]

Draft PR because this still needs to be tested.

This potentially fixes: https://github.com/AsteroidOS/meta-smartwatch/issues/253

[^1]: https://github.com/openembedded/meta-openembedded/commit/3309a9d4dde1b8cbab60322ec24e121330e23cea
[^2]: https://github.com/openembedded/meta-openembedded/commit/145ae5af9ef45f566f07751a2c2ea6c224e71a24