### PR TITLE
ngfd: Bump SRCREV

### DIFF
--- a/recipes-nemomobile/ngfd/ngfd_git.bb
+++ b/recipes-nemomobile/ngfd/ngfd_git.bb
@@ -11,7 +11,7 @@ SRC_URI = "gitsm://github.com/sailfishos/ngfd.git;protocol=https;branch=master \
            file://0001-ngf-Use-relative-path.patch \
            file://0002-ffmemless-Reserve-enough-space-for-sprintf.patch \
            "
-SRCREV = "57ad06b6df7052a668bdba876ea3dedb8f27d4ef"
+SRCREV = "402e45f4e03e901d0bea7716d206b4ffae7406f4"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This includes a crash fix for the ffmemless plugin(https://github.com/sailfishos/ngfd/commit/80d356b1c410954c756d3f2cc783a4608e0122b9).

This fixes ngfd from crashing when the alarm fires on `hoki`.