### PR TITLE
Several fixes for build errors as well as refactoring of how users and groups are handled

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -4,6 +4,7 @@ LICENSE = "GPL-2.0-only"
 
 # Inherit this to be able to produce OE SDKs that are fully capable of building Qt5 code
 inherit populate_sdk_qt5
+inherit asteroid-users
 
 IMAGE_FEATURES += "package-management debug-tweaks"
 
@@ -12,12 +13,6 @@ kernel-modules base-files base-passwd systemd busybox iproute2 connman pam-plugi
 pulseaudio-server openssh-sshd openssh-sftp-server openssh-scp dsme mce ngfd nfcd timed sensorfw resize-rootfs mapplauncherd-booster-qtcomponents usb-moded ofono \
 ${@oe.utils.conditional('MACHINE_HAS_WLAN', 'true', 'iproute2 wpa-supplicant connman-client', '', d)} \
 qtgraphicaleffects-qmlplugins supported-languages ttf-asteroid-fonts asteroid-launcher asteroid-calculator asteroid-calendar asteroid-stopwatch asteroid-settings asteroid-timer asteroid-alarmclock asteroid-weather asteroid-music asteroid-btsyncd asteroid-flashlight asteroid-diamonds"
-
-EXTRA_USERS_PARAMS = "groupadd system; \
-                      groupadd gps; \
-                      groupadd datetime; \
-                      groupadd -f -g 1024 mtp; \
-                      useradd -p '' -G 'audio,video,system,wheel,gps,sailfish-datetime,datetime,mtp,users,input' ceres"
 
 IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_ROOTFS_EXTRA_SPACE = "131072"

--- a/classes/asteroid-users.bbclass
+++ b/classes/asteroid-users.bbclass
@@ -1,0 +1,21 @@
+SUMMARY = "Creates users and groups for AsteroidOS"
+inherit useradd
+
+USERADD_PACKAGES = "${PN}"
+
+# Various recipes in meta-asteroid assume that ceres has UID 1000 and GID 1000.
+CERES_UID = "1000"
+CERES_GID = "1000"
+
+# When adding non-system groups, fixate their group ID to avoid potential
+# collisions when the ceres group is created, because otherwise, without
+# an explicitly set group ID, the system might just pick ID 1000. But that
+# ID is intended to be used for the ceres group.
+# Another way would be to just create the ceres group first. However, it is
+# cleaner to nail down the non-system group IDs, making their creation and
+# ID assignment deterministic.
+# (For the system groups, this is not done, since none of the system groups
+# require a specific ID, unlike the ceres user group.)
+GROUPADD_PARAM:${PN} = "-r system ; -r gps ; -r datetime ; -g 1024 mtp; -g 1050 sailfish-datetime; -g ${CERES_GID} ceres"
+
+USERADD_PARAM:${PN} = "-m -p '' -u ${CERES_UID} -g ${CERES_GID} -G audio,video,system,wheel,gps,sailfish-datetime,datetime,mtp,users,input ceres"

--- a/recipes-asteroid/supported-languages/supported-languages_git.bb
+++ b/recipes-asteroid/supported-languages/supported-languages_git.bb
@@ -15,18 +15,18 @@ RDEPENDS:${PN} += "source-han-sans-cn-fonts source-han-sans-kr-fonts ttf-lohit t
 
 FILES:${PN} += "/etc/systemd/system/user@.service.d/ /usr/lib/systemd/user/ /usr/share/supported-languages/ /home/.system/var/lib/environment/1000"
 
-INSANE_SKIP:${PN} += "host-user-contaminated"
+inherit asteroid-users
 
 do_install:append() {
     install -d ${D}/etc/systemd/system/user@.service.d/
     cp ../localeEnv.conf ${D}/etc/systemd/system/user@.service.d/locale.conf
 
-    install -d ${D}/home/.system/var/lib/environment/1000/
-    cp ../locale.conf ${D}/home/.system/var/lib/environment/1000/locale.conf
+    install -d ${D}/home/.system/var/lib/environment/${CERES_UID}/
+    cp ../locale.conf ${D}/home/.system/var/lib/environment/${CERES_UID}/locale.conf
 
     # TODO: Ensure this only allows asteroid-settings to write to this file, so
     # that others apps cannot set environment variables
-    chown 1000:1000 ${D}/home/.system/var/lib/environment/1000/locale.conf # ceres:ceres
+    chown ceres:ceres ${D}/home/.system/var/lib/environment/${CERES_UID}/locale.conf
 
     install -d ${D}/usr/share/supported-languages/
     cp ${S}/*.conf ${D}/usr/share/supported-languages/

--- a/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0005-Use-strlcpy-instead-of-snprintf-for-string-copy.patch
+++ b/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event/0005-Use-strlcpy-instead-of-snprintf-for-string-copy.patch
@@ -1,0 +1,32 @@
+From 95a06fe413a36f16b86f0afe826a4f6b0cd24044 Mon Sep 17 00:00:00 2001
+From: Carlos Rafael Giani <crg7475@mailbox.org>
+Date: Mon, 10 Feb 2025 21:12:36 +0100
+Subject: [PATCH] Use strlcpy() instead of snprintf() for string copy
+
+Using snprintf() that way is risky, because it leads to bugs if the
+name string contains format specifiers. The compiler reports this,
+and since -Werror is on, causes the build to fail with:
+
+    error: format not a string literal and no format arguments [-Werror=format-security]
+
+Fix this by using strlcpy() instead of snprintf().
+---
+ bluetooth-rfkill-event/bluetooth_rfkill_event.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bluetooth-rfkill-event/bluetooth_rfkill_event.c b/bluetooth-rfkill-event/bluetooth_rfkill_event.c
+index bff3075..a26032c 100644
+--- a/bluetooth-rfkill-event/bluetooth_rfkill_event.c
++++ b/bluetooth-rfkill-event/bluetooth_rfkill_event.c
+@@ -1082,7 +1082,7 @@ static int rfkill_switch_add(struct rfkill_event *event)
+     /* based on chip read its config file, if any, and define the hciattach utility used to dowload the patch */
+     if (!strncmp(rfkill_name, sysname, strlen(rfkill_name))) {
+ 	read_config(config_file);
+-	snprintf(hciattach, sizeof(hciattach), patcher_impl[main_opts.patcher].name);
++	strlcpy(hciattach, patcher_impl[main_opts.patcher].name, sizeof(hciattach));
+ 	type = BT_PWR;
+     } else if (g_str_has_prefix(sysname, "hci")) {
+ 	type = BT_HCI;
+-- 
+2.43.0
+

--- a/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event_git.bb
+++ b/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event_git.bb
@@ -8,6 +8,7 @@ SRC_URI = "git://github.com/mer-hybris/bluetooth-rfkill-event.git;protocol=https
            file://0002-Store-custom-Bluetooth-address.patch;patchdir=.. \
            file://0003-Fix-loading-the-service-file.patch;patchdir=.. \
            file://0004-Remove-sysconfig-file.patch;patchdir=.. \
+           file://0005-Use-strlcpy-instead-of-snprintf-for-string-copy.patch;patchdir=.. \
            "
 SRCREV = "f411db38e8f6b49403f2e9a320083630f990bcbc"
 PR = "r1"

--- a/recipes-graphics/ttf-fonts/ttf-asteroid-fonts_git.bb
+++ b/recipes-graphics/ttf-fonts/ttf-asteroid-fonts_git.bb
@@ -8,6 +8,7 @@ INHIBIT_DEFAULT_DEPS = "1"
 
 inherit allarch
 inherit fontcache
+inherit asteroid-users
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-fonts.git;protocol=https;branch=master \
     file://69-emoji.conf"
@@ -27,6 +28,3 @@ do_install() {
 }
 
 FILES:${PN} += "/usr/share/fonts /home/ceres/.config/fontconfig/conf.d"
-
-# Installing files in `/home/ceres/`, owned by uid 1000, causes a host-contamination warning.
-INSANE_SKIP:${PN} += "host-user-contaminated"

--- a/recipes-navigation/geoclue/files/0001-Remove-hardcoded-CFLAGS-that-collide-with-Yocto-OE-C.patch
+++ b/recipes-navigation/geoclue/files/0001-Remove-hardcoded-CFLAGS-that-collide-with-Yocto-OE-C.patch
@@ -1,0 +1,32 @@
+From 829733b2fe098cf542621b8291f10390f3c609a3 Mon Sep 17 00:00:00 2001
+From: Carlos Rafael Giani <crg7475@mailbox.org>
+Date: Tue, 11 Feb 2025 14:32:22 +0100
+Subject: [PATCH] Remove hardcoded CFLAGS that collide with Yocto/OE CFLAGS
+
+Yocto sets the -Wformat -Wformat-security CFLAGS. The hardcoded -Wno-format
+undoes -Wformat, leaving -Wformat-security . This causes this error:
+
+    error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
+
+Since there are no CFLAGS in that line that are somehow distinct or
+strictly necessary for the build, just remove the entire line.
+---
+ configure.ac | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index b8421f1..fac8ad4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -64,8 +64,6 @@ DBUS_SERVICES_DIR="${datadir}/dbus-1/services"
+ AC_SUBST(DBUS_SERVICES_DIR)
+ AC_DEFINE_UNQUOTED(DBUS_SERVICES_DIR, "$DBUS_SERVICES_DIR", [Where services dir for D-Bus is])
+ 
+-CFLAGS="$CFLAGS -g -Wall -Wno-format"
+-
+ # -----------------------------------------------------------
+ # gtk+
+ # -----------------------------------------------------------
+-- 
+2.43.0
+

--- a/recipes-navigation/geoclue/geoclue_0.12.99.bb
+++ b/recipes-navigation/geoclue/geoclue_0.12.99.bb
@@ -12,7 +12,8 @@ DEPENDS = "glib-2.0 dbus dbus-glib libxml2 libxslt-native dbus-glib-native pytho
 
 inherit autotools pkgconfig gtk-doc
 
-SRC_URI = "http://freedesktop.org/~hadess/geoclue-0.12.99.tar.gz"
+SRC_URI = "http://freedesktop.org/~hadess/geoclue-0.12.99.tar.gz \
+           file://0001-Remove-hardcoded-CFLAGS-that-collide-with-Yocto-OE-C.patch"
 
 SRC_URI[md5sum] = "779245045bfeeec4853da8baaa3a18e6"
 SRC_URI[sha256sum] = "fe396c91cb52de4219281f4d9223156338fc03670d34700281e86d1399b80a72"

--- a/recipes-nemomobile/dsme/dsme/0002-Fix-and-improve-alarm-time-serialization.patch
+++ b/recipes-nemomobile/dsme/dsme/0002-Fix-and-improve-alarm-time-serialization.patch
@@ -1,0 +1,112 @@
+From 17ebc6b0085fea1e4f7fdeb9b3787eba6b2bdc5a Mon Sep 17 00:00:00 2001
+From: Carlos Rafael Giani <crg7475@mailbox.org>
+Date: Mon, 10 Feb 2025 22:21:48 +0100
+Subject: [PATCH] Fix and improve alarm time serialization
+
+* Previously, the code assumed that time_t fits in the long type.
+  This is not necessarily the case, and in fact breaks in Yocto builds
+  when -Werror=format-security is used. Instead, use intmax_t for
+  serializing (because then, the PRIdMAX format specifier can be used).
+  For deserializing, use strtoll() (which is safer than fscanf), and
+  check that the parsed integer fits in time_t.
+* Add fsync(fileno(fh)) to the serialization to ensure that the alarm
+  time is written to disk.
+---
+ modules/alarmtracker.c | 44 ++++++++++++++++++++++++++++++++++--------
+ 1 file changed, 36 insertions(+), 8 deletions(-)
+
+diff --git a/modules/alarmtracker.c b/modules/alarmtracker.c
+index ca110ae..281ed40 100644
+--- a/modules/alarmtracker.c
++++ b/modules/alarmtracker.c
+@@ -57,6 +57,8 @@
+ #include <time.h>
+ #include <errno.h>
+ #include <string.h>
++#include <stdlib.h>
++#include <inttypes.h>
+ 
+ /* ========================================================================= *
+  * Constants
+@@ -64,6 +66,17 @@
+ /** Prefix to use for all logging from this module */
+ #define PFIX "alarmtracker: "
+ 
++/* These TIME_T_MIN and TIME_T_MAX definitions are from:
++ * https://github.com/cybertk/android-bash/blob/7b68d0da37039c5dcdc950011e7c02e02384bfa3/lib/sh/mktime.c */
++
++#ifndef TIME_T_MIN
++#define TIME_T_MIN (0 < (time_t) -1 ? (time_t) 0 \
++		    : ~ (time_t) 0 << (sizeof (time_t) * CHAR_BIT - 1))
++#endif
++#ifndef TIME_T_MAX
++#define TIME_T_MAX (~ (time_t) 0 - TIME_T_MIN)
++#endif
++
+ /*
+  * Store the alarm queue state in a file; it is used to restore the alarm queue state
+  * when the module is loaded.
+@@ -212,6 +225,8 @@ static void
+ alarmtracker_alarmtime_load(void)
+ {
+     FILE *fh = 0;
++    char buffer[32];
++    intmax_t data = 0;
+ 
+     /* Reset value */
+     alarmtracker_alarmtime_cached = 0;
+@@ -224,15 +239,27 @@ alarmtracker_alarmtime_load(void)
+         goto EXIT;
+     }
+ 
+-    long data = 0;
+-    if( errno = 0, fscanf(fh, "%ld", &data) != 1 ) {
+-        dsme_log(LOG_DEBUG, PFIX"%s: read error: %m", ALARM_STATE_FILE);
++    if (!fgets(buffer, sizeof(buffer), fh)) {
++        dsme_log(LOG_WARNING, PFIX"%s: read error or empty file: %m", ALARM_STATE_FILE);
++        goto EXIT;
++    }
++
++    errno = 0;
++    data = strtoll(buffer, NULL, 10);
++    if (errno != 0) {
++        dsme_log(LOG_WARNING, PFIX"%s: conversion error: %m", ALARM_STATE_FILE);
++        goto EXIT;
++    }
++
++    if (data < (intmax_t)TIME_T_MIN || data > (intmax_t)TIME_T_MAX) {
++        dsme_log(LOG_WARNING, PFIX"%s: alarm time out of range: %" PRIdMAX,
++                 ALARM_STATE_FILE, data);
+         goto EXIT;
+     }
+ 
+     alarmtracker_alarmtime_cached  = (time_t)data;
+-    dsme_log(LOG_DEBUG, PFIX"Alarm queue head restored: %ld",
+-             alarmtracker_alarmtime_current);
++    dsme_log(LOG_DEBUG, PFIX"Alarm queue head restored: %" PRIdMAX,
++             (intmax_t)alarmtracker_alarmtime_current);
+ 
+ EXIT:
+     alarmtracker_alarmtime_update(alarmtracker_alarmtime_cached);
+@@ -262,14 +289,15 @@ alarmtracker_alarmtime_save(void)
+         goto EXIT;
+     }
+ 
+-    if( fprintf(fh, "%ld\n", alarmtracker_alarmtime_current) < 0) {
++    if( fprintf(fh, "%" PRIdMAX "\n",
++                (intmax_t)alarmtracker_alarmtime_current) < 0) {
+         dsme_log(LOG_WARNING, PFIX"%s: can't write: %m",
+                  ALARM_STATE_FILE_TMP);
+         goto EXIT;
+     }
+ 
+-    if( fflush(fh) == EOF ) {
+-        dsme_log(LOG_WARNING, PFIX"%s: can't flush: %m",
++    if( fflush(fh) == EOF || fsync(fileno(fh)) == -1 ) {
++        dsme_log(LOG_WARNING, PFIX"%s: can't flush/fsync: %m",
+                  ALARM_STATE_FILE_TMP);
+         goto EXIT;
+     }
+-- 
+2.43.0
+

--- a/recipes-nemomobile/dsme/dsme_git.bb
+++ b/recipes-nemomobile/dsme/dsme_git.bb
@@ -4,7 +4,8 @@ LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
 SRC_URI = "gitsm://github.com/sailfishos/dsme.git;protocol=https;branch=master \
-    file://dsme.service"
+           file://0002-Fix-and-improve-alarm-time-serialization.patch \
+           file://dsme.service"
 SRCREV = "d1518176a68ce416fd19515c0b88da2b48ce606a"
 PR = "r1"
 PV = "+git${SRCPV}"
@@ -24,7 +25,6 @@ do_configure:prepend() {
 }
 
 do_compile() {
-    find . -type f -print0 | xargs -0 sed -i "s/\-Werror//"
     oe_runmake V=1
 }
 

--- a/recipes-nemomobile/lipstick/lipstick_git.bb
+++ b/recipes-nemomobile/lipstick/lipstick_git.bb
@@ -20,7 +20,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 DEPENDS += "timed qtbase qtsensors qtdeclarative qtwayland mlite dbus dbus-glib libresourceqt qtsystems libngf-qt mce usb-moded-qt5 systemd wayland nemo-keepalive qttools-native mce-qt5"
 RDEPENDS:${PN} += "${PN}-locale"
 
-inherit qmake5 pkgconfig
+inherit qmake5 pkgconfig asteroid-users
 
 do_install:append() {
     install -d ${D}/usr/share/icons/hicolor/86x86/apps/
@@ -38,5 +38,3 @@ FILES:${PN} += "/usr/lib/qml/org/nemomobile/lipstick/liblipstickplugin.so /usr/l
 FILES:${PN}-dev += "/usr/lib/liblipstick-qt5.prl"
 FILES:${PN}-dbg += "/usr/lib/qml/org/nemomobile/lipstick/.debug"
 FILES:${PN}-locale += "/usr/share/translations"
-
-INSANE_SKIP:${PN} += "dev-deps host-user-contaminated"

--- a/recipes-nemomobile/timed/timed_git.bb
+++ b/recipes-nemomobile/timed/timed_git.bb
@@ -13,12 +13,9 @@ PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-inherit qmake5 useradd pkgconfig
+inherit qmake5 asteroid-users pkgconfig
 
 B = "${S}"
-
-USERADD_PACKAGES = "${PN}"
-GROUPADD_PARAM:${PN} = "sailfish-datetime"
 
 do_configure:prepend() {
     mkdir -p src/h/timed-qt5/


### PR DESCRIPTION
These commits introduce fixes for build errors that happen when -Werror is used during compilation. Until now, some rather ugly workarounds were being used that were fragile, for example, by using sed to remove "-Werror" from build scripts. The fixes here patch the code that causes -Werror to trigger build errors, making such hacks unnecessary.

These commits also rework how users and groups are configured. They introduce a new bbclass where AsteroidOS specific users and groups are created centrally. This removes the need for the "host-user-contaminated" `INSANE_SKIP`, and also uses named constants instead of hardcoded UIDs for the ceres user and group.