### PR TITLE
Fix geoclue postinstall

### DIFF
--- a/recipes-navigation/geoclue/geoclue_0.12.99.bb
+++ b/recipes-navigation/geoclue/geoclue_0.12.99.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=149a9c1e8e40b7453ce8c62ed489f481"
 
 DEPENDS = "glib-2.0 dbus dbus-glib libxml2 libxslt-native dbus-glib-native python3-six-native"
 
-inherit autotools pkgconfig gtk-doc
+inherit autotools gsettings pkgconfig gtk-doc
 
 SRC_URI = "http://freedesktop.org/~hadess/geoclue-0.12.99.tar.gz \
            file://0001-Remove-hardcoded-CFLAGS-that-collide-with-Yocto-OE-C.patch"
@@ -26,6 +26,5 @@ AUTO_LIBNAME_PKGS = ""
 FILES:${PN} += " \
     ${datadir}/dbus-1/services \
     ${datadir}/geoclue-providers \
-    ${datadir}/glib-2.0/schemas \
     ${datadir}/GConf/gsettings/geoclue \
 "


### PR DESCRIPTION
This fixes the postinstall step required with geoclue by adding gsettings to the inherited classes.  That class automatically performs the step of compiling the schemas using glib-compile-schemas and also adds the /usr/share/glib-2.0/schemas to the FILES variable for the project, which is why it was removed from this file.

The gsettings also has a postinstrm step that recompiles the schemas after the package is removed.

This fixes https://github.com/AsteroidOS/asteroid/issues/304