### PR TITLE
feat: remove obsolete mlite dependency from qml-asteroid

### DIFF
--- a/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
+++ b/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
@@ -10,7 +10,7 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 inherit cmake_qt5 pkgconfig
 
-DEPENDS += "extra-cmake-modules qtdeclarative qtsvg qtvirtualkeyboard mlite mapplauncherd-booster-qtcomponents qtdeclarative-native"
+DEPENDS += "extra-cmake-modules qtdeclarative qtsvg qtvirtualkeyboard mapplauncherd-booster-qtcomponents qtdeclarative-native"
 RDEPENDS:${PN} += "asteroid-machine-config qtsvg-plugins qtvirtualkeyboard asteroid-icons-ion"
 
 FILES:${PN} += "/usr/lib /usr/share/icons/asteroid/"


### PR DESCRIPTION
Not necessary anymore since
https://github.com/AsteroidOS/qml-asteroid/commit/10ed025324d92819cfa39dbb013fb5095c2fe108