### PR TITLE
Remove compile-time dependency on virtualkeyboard

### DIFF
--- a/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
+++ b/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
@@ -10,7 +10,7 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 inherit cmake_qt5 pkgconfig
 
-DEPENDS += "extra-cmake-modules qtdeclarative qtsvg qtvirtualkeyboard mapplauncherd-booster-qtcomponents qtdeclarative-native"
+DEPENDS += "extra-cmake-modules qtdeclarative qtsvg mapplauncherd-booster-qtcomponents qtdeclarative-native"
 RDEPENDS:${PN} += "asteroid-machine-config qtsvg-plugins qtvirtualkeyboard asteroid-icons-ion"
 
 FILES:${PN} += "/usr/lib /usr/share/icons/asteroid/"


### PR DESCRIPTION
This remove the compile-time dependency on qtvirtualkeyboard because it is not needed.  See also https://github.com/AsteroidOS/qml-asteroid/pull/88 for the corresponding change in the qml-asteroid build.