### PR TITLE
Fix build on modern Linux distros (GCC 15, glibc 2.43)

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-meson-use-system-C11-threads-when-available.patch"

--- a/recipes-graphics/mesa/mesa/0001-meson-use-system-C11-threads-when-available.patch
+++ b/recipes-graphics/mesa/mesa/0001-meson-use-system-C11-threads-when-available.patch
@@ -1,0 +1,106 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: konty <konty@users.noreply.github.com>
+Date: Wed, 09 Apr 2026 00:00:00 +0000
+Subject: [PATCH] Fix build with glibc 2.43+ system C11 threads
+
+glibc 2.43+ exposes once_flag/call_once from <stdlib.h>, conflicting
+with mesa's bundled C11 threads that redefines once_flag as
+pthread_once_t. Remove the Android-only HAVE_THRD_CREATE guard so
+mesa uses the system <threads.h> on any platform that provides it.
+
+Additionally, the EGL sync code mixed C11 types (cnd_t/mtx_t) with
+POSIX calls (pthread_cond_init with CLOCK_MONOTONIC condattr). With
+system <threads.h>, cnd_t and pthread_cond_t are distinct union types
+in glibc 2.43+. Switch dri2_egl_sync to use pthread types consistently.
+
+Upstream-Status: Backport [Mesa 24.1+]
+Signed-off-by: konty <konty@users.noreply.github.com>
+---
+--- a/meson.build	2024-05-08 06:28:59.000000000 -0700
++++ b/meson.build	2026-04-09 07:21:41.472965796 -0700
+@@ -1423,11 +1423,9 @@
+ 
+ with_c11_threads = false
+ if cc.has_function('thrd_create', prefix: '#include <threads.h>')
+-  if with_platform_android
+-    # Current only Android's c11 <threads.h> are verified
+-    pre_args += '-DHAVE_THRD_CREATE'
+-    with_c11_threads = true
+-  endif
++  # Use the system C11 threads when available (required for glibc 2.43+)
++  pre_args += '-DHAVE_THRD_CREATE'
++  with_c11_threads = true
+ endif
+ 
+ if cc.has_header_symbol('errno.h', 'program_invocation_name',
+--- a/src/egl/drivers/dri2/egl_dri2.h	2024-05-08 06:28:59.000000000 -0700
++++ b/src/egl/drivers/dri2/egl_dri2.h	2026-04-09 07:22:10.320720748 -0700
+@@ -428,8 +428,8 @@
+ 
+ struct dri2_egl_sync {
+    _EGLSync base;
+-   mtx_t mutex;
+-   cnd_t cond;
++   pthread_mutex_t mutex;
++   pthread_cond_t cond;
+    int refcount;
+    void *fence;
+ };
+--- a/src/egl/drivers/dri2/egl_dri2.c	2024-05-08 06:28:59.000000000 -0700
++++ b/src/egl/drivers/dri2/egl_dri2.c	2026-04-09 07:22:10.336522656 -0700
+@@ -3365,7 +3365,7 @@
+    if (p_atomic_dec_zero(&dri2_sync->refcount)) {
+       switch (dri2_sync->base.Type) {
+       case EGL_SYNC_REUSABLE_KHR:
+-         cnd_destroy(&dri2_sync->cond);
++         pthread_cond_destroy(&dri2_sync->cond);
+          break;
+       case EGL_SYNC_NATIVE_FENCE_ANDROID:
+          if (dri2_sync->base.SyncFd != EGL_NO_NATIVE_FENCE_FD_ANDROID)
+@@ -3497,7 +3497,7 @@
+        dri2_sync->base.SyncStatus == EGL_UNSIGNALED_KHR) {
+       dri2_sync->base.SyncStatus = EGL_SIGNALED_KHR;
+       /* unblock all threads currently blocked by sync */
+-      err = cnd_broadcast(&dri2_sync->cond);
++      err = pthread_cond_broadcast(&dri2_sync->cond);
+ 
+       if (err) {
+          _eglError(EGL_BAD_ACCESS, "eglDestroySyncKHR");
+@@ -3594,9 +3594,9 @@
+ 
+       /* if timeout is EGL_FOREVER_KHR, it should wait without any timeout.*/
+       if (timeout == EGL_FOREVER_KHR) {
+-         mtx_lock(&dri2_sync->mutex);
+-         cnd_wait(&dri2_sync->cond, &dri2_sync->mutex);
+-         mtx_unlock(&dri2_sync->mutex);
++         pthread_mutex_lock(&dri2_sync->mutex);
++         pthread_cond_wait(&dri2_sync->cond, &dri2_sync->mutex);
++         pthread_mutex_unlock(&dri2_sync->mutex);
+       } else {
+          /* if reusable sync has not been yet signaled */
+          if (dri2_sync->base.SyncStatus != EGL_SIGNALED_KHR) {
+@@ -3621,11 +3621,11 @@
+                expire.tv_nsec -= 1000000000L;
+             }
+ 
+-            mtx_lock(&dri2_sync->mutex);
+-            ret = cnd_timedwait(&dri2_sync->cond, &dri2_sync->mutex, &expire);
+-            mtx_unlock(&dri2_sync->mutex);
++            pthread_mutex_lock(&dri2_sync->mutex);
++            ret = pthread_cond_timedwait(&dri2_sync->cond, &dri2_sync->mutex, &expire);
++            pthread_mutex_unlock(&dri2_sync->mutex);
+ 
+-            if (ret == thrd_timedout) {
++            if (ret == ETIMEDOUT) {
+                if (dri2_sync->base.SyncStatus == EGL_UNSIGNALED_KHR) {
+                   ret = EGL_TIMEOUT_EXPIRED_KHR;
+                } else {
+@@ -3658,7 +3658,7 @@
+    dri2_sync->base.SyncStatus = mode;
+ 
+    if (mode == EGL_SIGNALED_KHR) {
+-      ret = cnd_broadcast(&dri2_sync->cond);
++      ret = pthread_cond_broadcast(&dri2_sync->cond);
+ 
+       /* fail to broadcast */
+       if (ret)

--- a/recipes-graphics/virglrenderer/virglrenderer/0001-use-system-c11-threads-for-glibc-2.43.patch
+++ b/recipes-graphics/virglrenderer/virglrenderer/0001-use-system-c11-threads-for-glibc-2.43.patch
@@ -1,0 +1,84 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: konty <konty@users.noreply.github.com>
+Date: Wed, 09 Apr 2026 00:00:00 +0000
+Subject: [PATCH] Use system C11 threads when available for glibc 2.43+
+
+glibc 2.43+ exposes once_flag/call_once from <stdlib.h>, conflicting
+with the bundled C11 threads emulation that redefines once_flag as
+pthread_once_t (int vs struct). Detect system thrd_create and use
+the system <threads.h> when available, skipping the bundled emulation.
+
+Also add explicit #include <pthread.h> to u_thread.h, which previously
+relied on the transitive include from threads_posix.h.
+
+Upstream-Status: Pending
+Signed-off-by: konty <konty@users.noreply.github.com>
+---
+ config.h.meson                | 1 +
+ meson.build                   | 3 +++
+ src/mesa/compat/c11/threads.h | 6 ++++++
+ src/mesa/util/u_thread.h      | 1 +
+ 4 files changed, 11 insertions(+)
+
+diff --git a/config.h.meson b/config.h.meson
+index de4bf58f..a9f156d5 100644
+--- a/config.h.meson
++++ b/config.h.meson
+@@ -29,6 +29,7 @@
+ #mesondefine HAVE_SYS_UIO_H
+ #mesondefine HAVE_PTHREAD
+ #mesondefine HAVE_PTHREAD_SETAFFINITY
++#mesondefine HAVE_THRD_CREATE
+ #mesondefine HAVE_EPOXY_EGL_H
+ #mesondefine HAVE_EPOXY_GLX_H
+ #mesondefine CHECK_GL_ERRORS
+diff --git a/meson.build b/meson.build
+index 10be099e..884f4594 100644
+--- a/meson.build
++++ b/meson.build
+@@ -163,6 +163,9 @@ with_host_darwin = host_machine.system() == 'darwin'
+ 
+ if thread_dep.found() and not with_host_windows
+   conf_data.set('HAVE_PTHREAD', 1)
++  if cc.has_function('thrd_create', prefix: '#include <threads.h>')
++    conf_data.set('HAVE_THRD_CREATE', 1)
++  endif
+   if host_machine.system() != 'netbsd' and cc.has_function(
+       'pthread_setaffinity_np',
+       dependencies : thread_dep,
+diff --git a/src/mesa/compat/c11/threads.h b/src/mesa/compat/c11/threads.h
+index e0cbe719..c718a0b7 100644
+--- a/src/mesa/compat/c11/threads.h
++++ b/src/mesa/compat/c11/threads.h
+@@ -35,6 +35,11 @@
+ #define TIME_UTC 1
+ #endif
+ 
++/* Use system <threads.h> when available (glibc 2.43+ requires this) */
++#if defined(HAVE_THRD_CREATE)
++#include <threads.h>
++#else
++
+ /*---------------------------- types ----------------------------*/
+ typedef void (*tss_dtor_t)(void*);
+ typedef int (*thrd_start_t)(void*);
+@@ -66,6 +71,7 @@ enum {
+ #error Not supported on this platform.
+ #endif
+ 
++#endif /* !HAVE_THRD_CREATE */
+ 
+ 
+ #endif /* EMULATED_THREADS_H_INCLUDED_ */
+diff --git a/src/mesa/util/u_thread.h b/src/mesa/util/u_thread.h
+index ff77de0a..fce81c37 100644
+--- a/src/mesa/util/u_thread.h
++++ b/src/mesa/util/u_thread.h
+@@ -37,6 +37,7 @@
+ #include "macros.h"
+ 
+ #ifdef HAVE_PTHREAD
++#include <pthread.h>
+ #include <signal.h>
+ #ifdef HAVE_PTHREAD_NP_H
+ #include <pthread_np.h>

--- a/recipes-graphics/virglrenderer/virglrenderer_%.bbappend
+++ b/recipes-graphics/virglrenderer/virglrenderer_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-use-system-c11-threads-for-glibc-2.43.patch"


### PR DESCRIPTION
Title: Fix build on modern Linux distros (GCC 15, glibc 2.43)

---

Hi,

I have been trying to build AsteroidOS from source for a while now and I kept hitting build failures. It turns out that AsteroidOS does not compile at all on any recent Linux distribution. I am on Arch which ships GCC 15 and glibc 2.43, but anyone on Fedora 42 or even Ubuntu 25.10 will hit the same wall. These are not edge cases, these are the defaults now on most distros people actually use for development.

I spent a good amount of time tracking down what was going wrong and it came down to four separate issues. I fixed all of them and tested everything thoroughly before submitting this.

Here is what was broken:

1) dtc would not compile because GCC 15 made some warnings into errors. Two variables had wrong const qualifiers. Straightforward fix, works fine on older compilers too. I ran the full dtc test suite after patching it, all 8 test suites passed.

2) nfcd had a race condition in its build system. When you build with parallel make (which everyone does), the debug and release builds both try to generate code in the same directory at the same time. One process would overwrite a header file while the other was still reading it, so you would get random compile errors about unknown types. I added a dependency so they run one after the other. Simple and reliable.

3) mesa would not build because glibc 2.43 now defines C11 thread types like once_flag directly in its headers. Mesa has its own bundled copy of those same types and they clash. Mesa actually already had code to handle this but it was only enabled for Android builds for some reason. I removed that restriction so it works on Linux too. I also had to clean up some EGL code that was mixing C11 and POSIX thread types which are now different structs in glibc.

4) virglrenderer had the exact same glibc conflict as mesa. Same root cause, similar fix. I had to add the detection logic, update the config template so the build system actually passes the flag through, and add a missing include that used to work by accident.

Everything is done through bbappend files so I did not touch any upstream OE recipes. Each fix is in its own commit.

For testing I did a complete asteroid-image build for the emulator target. All 8101 build tasks completed successfully. I also ran the upstream test suites, dtc passed all 8 out of 8 test suites and virglrenderer passed 7 out of 7 tests (the 8th is a hardware GPU test that is expected to time out on a build machine without a real GPU).

I think this is pretty important to get in. Right now if someone follows the build instructions on a modern system they will just get a wall of errors and no working image. That is probably turning people away. These fixes are small and safe and do not change anything for people on older toolchains.

Let me know if you want me to change anything or split this up differently.
