### PR TITLE
flex: apply upstreamed patch to this version

### DIFF
--- a/recipes-devtools/flex/flex/0001-Match-malloc-signature-to-its-use.patch
+++ b/recipes-devtools/flex/flex/0001-Match-malloc-signature-to-its-use.patch
@@ -1,0 +1,22 @@
+From 6b6610ad3e0f84c212231f08d9433e7ba4b3e3f6 Mon Sep 17 00:00:00 2001
+From: Richard Barnes <rbarnes@umn.edu>
+Date: Wed, 2 Oct 2024 10:35:09 -0700
+Subject: [PATCH] Match `malloc` signature to its use
+
+---
+ lib/malloc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/malloc.c b/lib/malloc.c
+index 75e8ef9..701b9b3 100755
+--- a/lib/malloc.c
++++ b/lib/malloc.c
+@@ -3,7 +3,7 @@
+      
+      #include <sys/types.h>
+      
+-     void *malloc ();
++     void *malloc (size_t n);
+      
+      /* Allocate an N-byte block of memory from the heap.
+         If N is zero, allocate a 1-byte block.  */

--- a/recipes-devtools/flex/flex_%.bbappend
+++ b/recipes-devtools/flex/flex_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-Match-malloc-signature-to-its-use.patch"
+


### PR DESCRIPTION
The patch to allow flex to compile with gcc15 has already been upstreamed and merged, but oe-core uses only the tagged 2.6.4 version from 2017.  This simply applies just that one patch to flex to allow it to compile with gcc15.  This patch will no longer be needed when we advance past walnascar.

see https://github.com/westes/flex/pull/674/changes

Also related to https://github.com/AsteroidOS/meta-asteroid/pull/234