### PR TITLE
bluetooth-rfkill-event: document DESCRIPTION and systemd enablement

### DIFF
--- a/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event_git.bb
+++ b/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event_git.bb
@@ -1,4 +1,7 @@
 SUMMARY = "Bluetooth rfkill daemon, loads the Bluetooth firmware."
+DESCRIPTION = "Daemon that listens for Bluetooth rfkill events, loads device-specific firmware \
+and configuration (via bluetooth-rfkill-event-configs), and cooperates with the kernel rfkill \
+interface so BlueZ can start on hardware that needs this bootstrap step."
 HOMEPAGE = "https://github.com/mer-hybris/bluetooth-rfkill-event"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://../COPYING;md5=22b918b77fd38d7d7651669e03bdfd10"
@@ -21,8 +24,20 @@ RDEPENDS:${PN} += "rfkill bluetooth-rfkill-event-configs"
 inherit pkgconfig
 inherit systemd
 
+# systemd.bbclass defaults SYSTEMD_AUTO_ENABLE to "enable", so the unit is wired into the
+# image preset unless the distro or another bbappend overrides it. Keep this explicit so
+# image policy is obvious next to the install tweaks below.
+SYSTEMD_AUTO_ENABLE = "enable"
+
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "bluetooth-rfkill-event.service"
+
+# Upstream Makefile still installs a symlink under network.target.wants. Remove that tree
+# so activation follows only bluetooth-rfkill-event.service [Install] (WantedBy=multi-user.target
+# after patches) and systemd.bbclass enablement, avoiding a second, network.target-based enable path.
+#
+# Ordering: the unit uses Before=bluetooth.service so rfkill/firmware handling runs before
+# BlueZ's bluetooth.service.
 
 do_install() {
 	oe_runmake install INSTALL_ROOT=${D}

--- a/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event_git.bb
+++ b/recipes-core/bluetooth-rfkill-event/bluetooth-rfkill-event_git.bb
@@ -41,7 +41,7 @@ SYSTEMD_SERVICE:${PN} = "bluetooth-rfkill-event.service"
 
 do_install() {
 	oe_runmake install INSTALL_ROOT=${D}
-        rm -r ${D}/usr/lib/systemd/system/network.target.wants
+    rm -r ${D}/usr/lib/systemd/system/network.target.wants
 }
 
 FILES:${PN} += "${datadir}/libexec/bluetooth_rfkill_event/killall-wait.sh"


### PR DESCRIPTION
Add DESCRIPTION for the daemon role and configs dependency. Set SYSTEMD_AUTO_ENABLE explicitly and comment why network.target.wants is removed versus WantedBy=multi-user.target and Before=bluetooth.service.

Let me know if there is a PR Template, I couldn't find one.