### PR TITLE
mkcal: Bump SRCREV to fix datetime issues

### DIFF
--- a/recipes-qt/qt6/mkcal_git.bb
+++ b/recipes-qt/qt6/mkcal_git.bb
@@ -4,7 +4,7 @@ LICENSE = "LGPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE.LGPL2;md5=5f30f0716dfdd0d91eb439ebec522ec2"
 
 SRC_URI = "git://github.com/sailfishos/mkcal.git;protocol=https;branch=master"
-SRCREV = "1b5e8287081453122fcd3abea705c41bd781bb31"
+SRCREV = "4687242710462999b4f55fd82104e2aee53f9fdf"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"


### PR DESCRIPTION
See https://github.com/sailfishos/mkcal/pull/77 for reference. It fixes another Qt6 related issue.