### PR TITLE
mce: ship explicit blanking defaults to fix display never blanking on Qt6

### DIFF
--- a/recipes-nemomobile/mce/mce/builtin-gconf.values
+++ b/recipes-nemomobile/mce/mce/builtin-gconf.values
@@ -1,1 +1,3 @@
 /system/osso/dsm/display/display_brightness=5
+/system/osso/dsm/display/inhibit_blank_mode=0
+/system/osso/dsm/locks/tklock_blank_disable=0


### PR DESCRIPTION
On fresh Qt6 installs, the display never auto-blanks after first boot under certain circumstances. One of them i could reproduce was booting up first time with 100% charge and usb connected on sparrow.

mcetool status shows Blank inhibit: stay-on and Tklock autoblank policy: disabled, meaning MCE correctly detects user inactivity but refuses to start the dim and blank sequence regardless.

Inspection of /var/lib/mce/builtin-gconf.values on first boot reveals inhibit_blank_mode=3 and tklock_blank_disable=1. The currently shipped file only contains display_brightness=5 with no overrides for these keys, so whatever values end up in the file at runtime are what MCE runs with.

Issuing mcetool --set-inhibit-mode=disabled and
mcetool --set-tklock-blank=enabled, which write inhibit_blank_mode=0 and tklock_blank_disable=0 to the same file, restores correct blanking behaviour and persists across reboots. Adding these as explicit shipped defaults achieves the same result from first boot without manual intervention.

Confirmed broken on fresh first boot on sparrow (MSM8226, kernel 3.10) and belugaxl (MSM8909W, kernel 4.9). Confirmed fixed on both after the equivalent mcetool commands.
Afaiu and could test, the zero values are the standard disabled/allow-blanking defaults for any Nemo MCE setup and do not affect devices where these keys were already correct.