### PR TITLE
qtsensors: Install /etc/xdg/QtProject/Sensors.conf

### DIFF
--- a/recipes-qt/qt6/qtsensors/0001-Enable-sensorfw.patch
+++ b/recipes-qt/qt6/qtsensors/0001-Enable-sensorfw.patch
@@ -1,15 +1,15 @@
-From 3735894de2dfa6b3359c1cc7cff50ee08a461efe Mon Sep 17 00:00:00 2001
+From b9b8fc3c8ea1d83f10f61856385bcd640f54abd5 Mon Sep 17 00:00:00 2001
 From: Florent Revest <revestflo@gmail.com>
 Date: Sat, 9 May 2026 17:35:21 +0000
-Subject: [PATCH 1/4] Enable sensorfw
+Subject: [PATCH] Enable sensorfw
 
 Upstream-Status: Pending
 ---
  cmake/FindSensorfw.cmake                    |  2 +-
  src/plugins/sensors/CMakeLists.txt          |  7 +++----
- src/plugins/sensors/sensorfw/CMakeLists.txt | 12 +++++++++++-
+ src/plugins/sensors/sensorfw/CMakeLists.txt | 20 ++++++++++++++------
  src/sensors/configure.cmake                 |  7 +------
- 4 files changed, 16 insertions(+), 12 deletions(-)
+ 4 files changed, 19 insertions(+), 17 deletions(-)
 
 diff --git a/cmake/FindSensorfw.cmake b/cmake/FindSensorfw.cmake
 index c6238a92..1f3039a0 100644
@@ -43,10 +43,10 @@ index e7527d8f..66efaf9f 100644
  if (QT_FEATURE_winrt_sensors AND NOT SENSORS_PLUGINS OR "winrt" IN_LIST SENSORS_PLUGINS)
      add_subdirectory(winrt)
 diff --git a/src/plugins/sensors/sensorfw/CMakeLists.txt b/src/plugins/sensors/sensorfw/CMakeLists.txt
-index cc5e9dad..68eb0d56 100644
+index cc5e9dad..1cb36988 100644
 --- a/src/plugins/sensors/sensorfw/CMakeLists.txt
 +++ b/src/plugins/sensors/sensorfw/CMakeLists.txt
-@@ -28,9 +28,19 @@ qt_internal_add_plugin(sensorfwSensorPlugin
+@@ -28,11 +28,19 @@ qt_internal_add_plugin(sensorfwSensorPlugin
          Qt::DBus
          Qt::Network
          Qt::SensorsPrivate
@@ -54,6 +54,11 @@ index cc5e9dad..68eb0d56 100644
 +        PkgConfig::Sensorfw
  )
  
+-#### Keys ignored in scope 1:.:.:sensorfw.pro:<TRUE>:
+-# CONFIGFILES.files = "Sensors.conf"
+-# CONFIGFILES.path = "/etc/xdg/QtProject/"
+-# INSTALLS = "CONFIGFILES"
+-# OTHER_FILES = "plugin.json"
 +# sensord-qt6 public headers (e.g. datatypes/datarange.h) use Qt's `foreach`
 +# keyword, which qtsensors disables via QT_NO_FOREACH. Re-enable it for this
 +# plugin so the sensorfw headers compile.
@@ -64,9 +69,9 @@ index cc5e9dad..68eb0d56 100644
 +    set_property(TARGET sensorfwSensorPlugin PROPERTY COMPILE_DEFINITIONS "${_sensorfw_defs}")
 +endif()
 +
- #### Keys ignored in scope 1:.:.:sensorfw.pro:<TRUE>:
- # CONFIGFILES.files = "Sensors.conf"
- # CONFIGFILES.path = "/etc/xdg/QtProject/"
++install(FILES Sensors.conf
++        DESTINATION /etc/xdg/QtProject
++)
 diff --git a/src/sensors/configure.cmake b/src/sensors/configure.cmake
 index 95895794..2121309a 100644
 --- a/src/sensors/configure.cmake


### PR DESCRIPTION
Without that, the sensorfw backend is not used