### PR TITLE
qtbase: Enable tests and widgets on hybris

### DIFF
--- a/recipes-qt/qt6/qtbase_git.bbappend
+++ b/recipes-qt/qt6/qtbase_git.bbappend
@@ -5,7 +5,7 @@ SRC_URI += " file://0002-qplatforminputcontextfactory-Use-qtvirtualkeyboard-b.pa
 PACKAGECONFIG:append = " gles2 sql-sqlite glib fontconfig "
 
 # Remove dependencies to mesa on hybris-based machines
-PACKAGECONFIG:remove:hybris-machine = " tests widgets gl gbm kms "
+PACKAGECONFIG:remove:hybris-machine = " gl gbm kms "
 
 QT_CONFIG_FLAGS += "--no-feature-getentropy"
 


### PR DESCRIPTION
tests and widgets have been enabled for non-hybris (emulator, rinato, sparrow-mainline).
Enable them for hybris based machine as well.

This fixes the compilation of the toolchain, which failed because of qtpdf and qtwebengine.

qtpdf seems to depend on widgets.

```
| ERROR: Feature "webengine_printing_and_pdf": Forcing to "ON" breaks its condition:
|     TARGET Qt::PrintSupport AND QT_FEATURE_printer
| Condition values dump:
|     TARGET Qt::PrintSupport not found
|     QT_FEATURE_printer not evaluated
```
And
```
| -- Could NOT find Qt6Widgets (missing: Qt6Widgets_DIR) | CMake Error at src/pdfwidgets/CMakeLists.txt:4 (find_package):
|   Found package configuration file:
|
|     /workdir/build/tmp/work/armv7vehf-neon-oe-linux-gnueabi/qtpdf/6.11.2/recipe-sysroot/usr/lib/cmake/Qt6/Qt6Config.cmake
|
|   but it set Qt6_FOUND to FALSE so package "Qt6" is considered to be NOT
|   FOUND.  Reason given by package:
|
|   Failed to find required Qt component "Widgets".
|
|   Expected Config file at
|   "/workdir/build/tmp/work/armv7vehf-neon-oe-linux-gnueabi/qtpdf/6.11.2/recipe-sysroot/usr/lib/cmake/Qt6Widgets/Qt6WidgetsConfig.cmake"
|   does NOT exist
```