### PR TITLE
hybris-machine: Forcefully disable QtWebEngine

### DIFF
--- a/conf/machine/include/hybris-watch.inc
+++ b/conf/machine/include/hybris-watch.inc
@@ -3,6 +3,8 @@ MACHINEOVERRIDES =. "hybris-machine:"
 
 SERIAL_CONSOLE = "115200 ttyHSL0"
 
+QTWEBENGINE_SUPPORTED:forcevariable = "0"
+
 PREFERRED_PROVIDER_virtual/mesa = "libhybris"
 PREFERRED_PROVIDER_virtual/egl = "libhybris"
 PREFERRED_PROVIDER_virtual/libgles1 = "libhybris"


### PR DESCRIPTION
QtWebEngine is compiled by default as part of the Qt6 toolchain.

QtWebEngine requires gbm but that fails as libhybris doesn't provide it (https://github.com/libhybris/libhybris/issues/570).

Disable QtWebEngine to fix the toolchain build.