### PR TITLE
asteroid-btsyncd: Drop the nemo-qml-plugin-systemsettings dependency

### DIFF
--- a/recipes-asteroid/asteroid-btsyncd/asteroid-btsyncd_git.bb
+++ b/recipes-asteroid/asteroid-btsyncd/asteroid-btsyncd_git.bb
@@ -11,7 +11,7 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 inherit qt6-cmake gsettings pkgconfig
 
-DEPENDS += "qml-asteroid qtbase glibmm amber-mpris qttools-native nemo-qml-plugin-systemsettings"
+DEPENDS += "qml-asteroid qtbase glibmm amber-mpris qttools-native"
 RDEPENDS:${PN} += "glibmm amber-mpris systemd"
 
 FILES:${PN} += "/usr/bin/ /usr/lib/systemd/user/ /usr/share/glib-2.0/schemas /usr/share/translations/ /usr/lib/systemd/user/default.target.wants/"


### PR DESCRIPTION
No longer needed since
https://github.com/AsteroidOS/asteroid-btsyncd/pull/43