### PR TITLE
qofonoext: fix Qt6/CMake build

### DIFF
--- a/recipes-nemomobile/qofonoext/qofonoext_git.bb
+++ b/recipes-nemomobile/qofonoext/qofonoext_git.bb
@@ -9,7 +9,9 @@ PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-DEPENDS += "ofono qtbase libqofono"
+DEPENDS += "ofono qtbase qtdeclarative qtdeclarative-native libqofono extra-cmake-modules"
 inherit qt6-cmake pkgconfig
 
-FILES:${PN} += "/usr/lib/qml/org/nemomobile/ofono/"
+EXTRA_OECMAKE += "-DQT_MAJOR_VERSION=6"
+
+FILES:${PN} += "${libdir}/qt6/qml/org/nemomobile/ofono/"


### PR DESCRIPTION
The libqofonoext source is a CMake/Qt6 project but the recipe was not fully wired for it:

- find_package(ECM) needs extra-cmake-modules in DEPENDS.
- CMakeLists defaults QT_MAJOR_VERSION to 5; force 6 via EXTRA_OECMAKE.
- The QML plugin needs Qt6Qml: add qtdeclarative and qtdeclarative-native (host Qt6QmlTools).
- The plugin installs under ${libdir}/qt6/qml, not the old Qt5 /usr/lib/qml path, so fix FILES to ship it.