### PR TITLE
usb-moded: drop libdsme dependency

### DIFF
--- a/recipes-nemomobile/usb-moded/usb-moded_git.bb
+++ b/recipes-nemomobile/usb-moded/usb-moded_git.bb
@@ -22,7 +22,7 @@ inherit autotools pkgconfig
 
 B = "${WORKDIR}/git"
 EXTRA_OECONF="--enable-systemd --enable-debug --enable-app-sync --enable-connman"
-DEPENDS += "dbus dbus-glib glib-2.0 udev kmod systemd libdsme"
+DEPENDS += "dbus dbus-glib glib-2.0 udev kmod systemd"
 
 do_configure:prepend() {
     sed -i "s@systemd-daemon@systemd@" configure.ac


### PR DESCRIPTION
usb-moded only links libdsme under the MEEGOLOCK build flag (--enable-meegodevlock), which defaults to false and is never enabled by this recipe. No dsme code was compiled and libdsme was never linked, so the DEPENDS entry only pulled unused headers into the sysroot.

Part of weaning AsteroidOS off dsme; no functional change.