### PR TITLE
distro: resolve llvm-native and clang-native sysroot conflict

### DIFF
--- a/conf/distro/asteroid.conf
+++ b/conf/distro/asteroid.conf
@@ -25,6 +25,10 @@ DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 
 PREFERRED_PROVIDER_jpeg = "libjpeg-turbo"
 PREFERRED_PROVIDER_jpeg-native = "libjpeg-turbo-native"
+# When meta-clang is present, make clang-native satisfy llvm-native requests
+# so oe-core's llvm never builds and the two do not clash in native sysroots.
+PROVIDES:append:pn-clang-native = " llvm-native"
+PREFERRED_PROVIDER_llvm-native = "clang-native"
 
 PREFERRED_VERSION_geoclue = "0.12.99"
 


### PR DESCRIPTION
When meta-clang is present in the layer stack, `clang-native` and
oe-core's `llvm-native` both attempt to install the full LLVM C API
headers into native recipe sysroots. This causes `do_prepare_recipe_sysroot`
to abort with a duplicate file error, blocking Qt6 builds for any watch
that is not aurora.

The fix from PR #248 (hybris-gki-watch.inc) works correctly but is scoped
to GKI watches only. Moving it to `asteroid.conf` covers all watches
building with meta-clang and is a no-op when meta-clang is absent.

Note: once PR #248 merges, the same two lines should be removed from
`conf/machine/include/hybris-gki-watch.inc` to avoid redundancy.