### PR TITLE
Add a Mesa driver shim for simpledrm

### DIFF
--- a/recipes-graphics/mesa-dri-simpledrm/mesa-dri-simpledrm/COPYING
+++ b/recipes-graphics/mesa-dri-simpledrm/mesa-dri-simpledrm/COPYING
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright © 2023 sleirsgoevy
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/recipes-graphics/mesa-dri-simpledrm/mesa-dri-simpledrm/mesa-dri-simpledrm.c
+++ b/recipes-graphics/mesa-dri-simpledrm/mesa-dri-simpledrm/mesa-dri-simpledrm.c
@@ -1,0 +1,19 @@
+#include <dlfcn.h>
+
+/*
+This is a temporary hack until Mesa upstream adds 2 lines to their code.
+https://gitlab.freedesktop.org/mesa/mesa/-/issues/8929
+*/
+
+void* __driDriverGetExtensions_simpledrm(void)
+{
+    /*
+     * NOTE: This does NOT require a Mediatek GPU.
+     * We fall back to software rendering.
+     * This just returns extensions for the simpledrm shim.
+     */
+    static void*(*ddge_mediatek)(void);
+    if(!ddge_mediatek)
+        ddge_mediatek = dlsym(dlopen("/usr/lib/dri/mediatek_dri.so", RTLD_NOW), "__driDriverGetExtensions_mediatek");
+    return ddge_mediatek();
+}

--- a/recipes-graphics/mesa-dri-simpledrm/mesa-dri-simpledrm_git.bb
+++ b/recipes-graphics/mesa-dri-simpledrm/mesa-dri-simpledrm_git.bb
@@ -1,0 +1,22 @@
+SUMMARY = "KMSRO stub for simpledrm"
+HOMEPAGE = "https://gitlab.postmarketos.org/wannjanjic/pmaports/-/blob/master/temp/mesa-dri-simpledrm"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d2c38ad85003f450ee297d1317a96e20"
+
+SRC_URI = "file://mesa-dri-simpledrm.c \
+           file://COPYING"
+
+S = "${UNPACKDIR}"
+
+RDEPENDS:${PN} = "mesa"
+
+do_compile() {
+        ${CC} ${LDFLAGS} mesa-dri-simpledrm.c -shared -o simpledrm_dri.so
+}
+
+do_install() {
+        install -d "${D}/usr/lib/dri"
+        install -m 0755 simpledrm_dri.so "${D}/usr/lib/dri/simpledrm_dri.so"
+}
+
+FILES:${PN} = "/usr/lib/dri/simpledrm_dri.so"


### PR DESCRIPTION
This pull request adds a package providing a simpledrm driver shim for Mesa. This allows Mesa to render to a simple framebuffer backed simpledrm device, which can be used on systems without a functioning GPU driver, which is particularly useful for development of close-to-mainline ports.