### PR TITLE
timed: Don't grant cap_sys_time

### DIFF
--- a/recipes-nemomobile/timed/timed_git.bb
+++ b/recipes-nemomobile/timed/timed_git.bb
@@ -41,10 +41,9 @@ do_install:append() {
     ln -s /usr/share/zoneinfo/Etc/GMT ${D}/var/lib/timed/localtime
 
     cp ${UNPACKDIR}/timed.conf ${D}/etc/dbus-1/system.d/
-}
 
-pkg_postinst:${PN}() {
-    setcap cap_sys_time+ep $D/usr/bin/timed
+    # nemo packaging grants cap_sys_time to the timed binary but we manage the
+    # time only via systemd so we explicitly don't grant timed the cap.
 }
 
 PACKAGE_WRITE_DEPS = "libcap-native"


### PR DESCRIPTION
Nowadays we only change time via systemd calls (in both qml-asteroid and asteroid-btsyncd) so we no longer use timed's ability to change the current time.

In fact, it's actively hurting us because on aurora for example it is changing system time to a broken RTC which sets back time to 1970 and which breaks assumptions made by some Google libraries and restart loops some daemons in the LXC container that both break some functionalities and make the UI significantly slower.