### PR TITLE
libngf-qt: pass PREFIX to qmake instead of moving headers

### DIFF
--- a/recipes-nemomobile/libngf/libngf-qt_git.bb
+++ b/recipes-nemomobile/libngf/libngf-qt_git.bb
@@ -14,10 +14,7 @@ S = "${WORKDIR}/git"
 DEPENDS += " qtbase qtdeclarative libngf qtfeedback dbus"
 inherit qt6-qmake pkgconfig
 
-do_install:append() {
-    mv ${D}/include/* ${D}/usr/include/
-    rmdir ${D}/include/
-}
+EXTRA_QMAKEVARS_PRE = "PREFIX=${prefix}"
 
 FILES:${PN} += "/usr/lib/qml/Nemo/Ngf /usr/lib/plugins/feedback"
 FILES:${PN}-dbg += "/opt /usr/lib/qml/Nemo/Ngf/.debug/"


### PR DESCRIPTION
src/src.pro installs its headers to $$PREFIX/include/ngf-qt6 and bakes the same path into the generated ngf-qt6.pc includedir. PREFIX is only defaulted (to /usr/local) in the top-level .pro, and that assignment does not propagate into the subdirs child, while qt6-qmake configures Qt paths through qt.conf and never passes PREFIX. As a result the headers were installed to /include/ngf-qt6 and the .pc advertised a bogus -I/include/ngf-qt6; the recipe papered over this by mv-ing the headers, which flattened them into /usr/include (not /usr/include/ngf-qt6 as the .pc claims), forcing a workaround in asteroid-launcher.

Pass PREFIX=${prefix} on the qmake command line so it propagates into the subdir: headers now install to /usr/include/ngf-qt6 and the .pc includedir matches. Drop the do_install mv hack.