### PR TITLE
usb-moded-qt6: pass PREFIX to qmake instead of moving headers

### DIFF
--- a/recipes-nemomobile/usb-moded/usb-moded-qt6_git.bb
+++ b/recipes-nemomobile/usb-moded/usb-moded-qt6_git.bb
@@ -14,7 +14,8 @@ S = "${WORKDIR}/git"
 DEPENDS += "qtbase usb-moded"
 inherit qt6-qmake pkgconfig
 
+EXTRA_QMAKEVARS_PRE = "PREFIX=${prefix}"
+
 do_install:append() {
-    mv ${D}/include ${D}/usr/
     install -m 644 -D ${UNPACKDIR}/usb-moded-qt6.pc ${D}/usr/lib/pkgconfig/
 }


### PR DESCRIPTION
src/src.pro installs headers to $$PREFIX/include/usb-moded-qt6, but the top-level subdirs .pro never defaults PREFIX, and qt6-qmake configures Qt paths through qt.conf without passing one. PREFIX was therefore empty in the subdir and headers landed in /include, which the recipe papered over by mv-ing the directory into /usr.

Pass PREFIX=${prefix} on the qmake command line (it propagates into the subdir) so headers install to /usr/include/usb-moded-qt6 directly and the generated .pc's includedir matches. Drop the do_install mv. Same fix as libngf-qt. The hand-shipped usb-moded-qt6.pc is kept: it works around a separate issue (upstream installs the generated .pc to a non-standard pkgconfig-qt6 dir where pkg-config won't find it).