### PR TITLE
ngfd: add a "notification" event that plays the notification sound

### DIFF
--- a/recipes-nemomobile/ngfd/ngfd/events.d/notification.ini
+++ b/recipes-nemomobile/ngfd/ngfd/events.d/notification.ini
@@ -1,0 +1,3 @@
+[notification]
+sound.filename = /usr/share/sounds/notification.wav
+sound.stream.media.role = notification


### PR DESCRIPTION
asteroid-launcher currently plays notification/unmute sounds via QtMultimedia ⁠SoundEffect, which keeps a PulseAudio stream open for the app’s lifetime. This prevents the audio sink from suspending and causes constant standby battery drain.
The launcher will switch to ⁠ngf, which plays sounds with a short-lived GStreamer pipeline that shuts down after playback, allowing the sink to suspend again. To support this, this change adds a new sound-only ⁠"notification" event to ⁠ngfd (existing ⁠notif_* events remain for haptics/LED).