### PR TITLE
usb-moded: change default to adb_mode

### DIFF
--- a/recipes-nemomobile/usb-moded/usb-moded/usb-moded/usb-moded.ini
+++ b/recipes-nemomobile/usb-moded/usb-moded/usb-moded/usb-moded.ini
@@ -1,2 +1,2 @@
 [usbmode]
-mode=developer_mode
+mode=adb_mode


### PR DESCRIPTION
A freshly flashed watch currently exposes SSH over USB-RNDIS.
This can have folowing issues for users who are not familiar with SSH:

- does not work at all on macOS hosts
- can clash with home networks that use the 192.168.2.x range
- ssigns the same fixed 192.168.2.15 to every watch, so two watches cannot even be connected to one host at the same

Changing to ADB as default would possibly impact devs that prefer SSH connection and now need to toggle it in the usbPage or using the D-Bus call direcly.