### PR TITLE
Add support for the uniLoader second-stage bootloader

### DIFF
--- a/classes/uniloader.bbclass
+++ b/classes/uniloader.bbclass
@@ -1,0 +1,50 @@
+#
+# This class builds the built Linux kernel, DTB, and initramfs into uniLoader
+#
+
+DEPENDS:append = " uniloader"
+
+# Can be either uniLoader or uniLoader.gz
+UNILOADER_IMAGE ?= "uniLoader"
+MACHINE_DEFCONFIG ?= "${MACHINE}_defconfig"
+
+# We are taking the place of the kernel here
+KERNEL_OUTPUT = "${B}/uniloader/${UNILOADER_IMAGE}"
+
+addtask do_prepare_uniloader after do_compile before do_deploy
+do_prepare_uniloader[depends] = "uniloader:do_install initramfs-android-image:do_image_complete"
+
+do_prepare_uniloader() {
+    # Ensure the kernel image is an executable format
+    if [[ ! "${KERNEL_IMAGETYPE}" =~ "^(Image|zImage|bzImage)$" ]]; then
+        echo "Error: Incompatible KERNEL_IMAGETYPE specified! (Specified: \"${KERNEL_IMAGETYPE}\", Compatible: \"Image\", \"zImage\", \"bzImage\")"
+        return 1
+    fi
+
+    # Copy the uniLoader source into our build directory
+    cp -r "${RECIPE_SYSROOT}/uniloader" "${B}/uniloader"
+
+    # Integrate the newly built kernel, dtb, and initramfs blobs into the source
+    cp "${B}/${KERNEL_OUTPUT_DIR}/${KERNEL_IMAGETYPE}" "${B}/uniloader/blob/Image"
+    cp "${B}/${KERNEL_OUTPUT_DIR}/dts/${KERNEL_DEVICETREE}" "${B}/uniloader/blob/dtb"
+    cp "${DEPLOY_DIR_IMAGE}/initramfs-android-image-${MACHINE}.cpio.gz" "${B}/uniloader/blob/ramdisk"
+}
+
+addtask do_configure_uniloader after do_prepare_uniloader before do_deploy
+
+do_configure_uniloader() {
+    cd "${B}/uniloader"
+    oe_runmake "${PARALLEL_MAKE}" "${MACHINE_DEFCONFIG}"
+}
+
+addtask do_compile_uniloader after do_configure_uniloader before do_deploy
+
+do_compile_uniloader() {
+    cd "${B}/uniloader"
+
+    # The Makefile doesn't seem to be able to find libgcc on its own in this environment,
+    # so we tell it where it is with LIBGCC.
+    # We also clear the LDFLAGS due to them containing GCC args but being passed to LD.
+    oe_runmake "${PARALLEL_MAKE}" ARCH="${TARGET_ARCH}" CROSS_COMPILE="${TARGET_PREFIX}" LDFLAGS="" \
+               LIBGCC="${RECIPE_SYSROOT}/usr/lib/${TARGET_SYS}/$(${TARGET_PREFIX}gcc -dumpversion)/libgcc.a"
+}

--- a/recipes-core/uniloader/uniloader_git.bb
+++ b/recipes-core/uniloader/uniloader_git.bb
@@ -1,0 +1,20 @@
+DESCRIPTION = "A simple second-stage bootloader which provides a clean environment for booting Linux"
+HOMEPAGE = "https;//github.com/ivoszbg/uniLoader.git"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ba925be40dd5b952d53f0414e95a491a"
+
+SRC_URI = "git://github.com/ivoszbg/uniLoader.git;branch=master;protocol=https"
+SRCREV = "831c31bac9fc93f4787d6349006766844fdeb7b2"
+S = "${WORKDIR}/git"
+
+SYSROOT_DIRS = "/uniloader"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d "${D}/uniloader"
+    cp -r "${S}"/* "${D}/uniloader"
+}
+
+FILES:${PN} = "/uniloader"


### PR DESCRIPTION
This pull request adds a package and a bbclass for the uniLoader second-stage bootloader. It is designed as a small shim which bundles the kernel, dtb, and initramfs inside itself, and provides a clean environment for booting Linux, free of the stock bootloader's interference (for example, adding hardcoded device tree overlays to the provided device tree).

This is mainly useful for ports using a close-to-mainline Linux kernel, although it could very well be possible to use it on downstream-based ports too if that were ever desired for some reason.