### PR TITLE
boot: Add disto and machine name to boot image

### DIFF
--- a/classes/abootimg.bbclass
+++ b/classes/abootimg.bbclass
@@ -14,7 +14,7 @@ do_deploy:append() {
              -r ${DEPLOY_DIR_IMAGE}/initramfs-android-image-${MACHINE}.cpio.gz \
              ${ABOOTIMG_ARGS}
 
-    cp ${B}/boot.img ${DEPLOYDIR}/boot.img
+    cp ${B}/boot.img ${DEPLOYDIR}/${DISTRO}-${MACHINE}-boot.img
 
     install -d ${D}/${KERNEL_IMAGEDEST}
     install -m 0644 ${B}/boot.img ${D}/${KERNEL_IMAGEDEST}

--- a/classes/mkboot.bbclass
+++ b/classes/mkboot.bbclass
@@ -15,7 +15,7 @@ do_deploy:append() {
     sed -i "s@%%RAMDISK_SIZE%%@$(stat --printf="%s" ${DEPLOY_DIR_IMAGE}/initramfs-android-image-${MACHINE}.cpio.gz)@" img_info
     mkboot . boot.img || { echo "mkboot failed"; exit 1; }
 
-    cp ${B}/boot.img ${DEPLOYDIR}/boot.img
+    cp ${B}/boot.img ${DEPLOYDIR}/${DISTRO}-${MACHINE}-boot.img
 
     install -d ${D}/${KERNEL_IMAGEDEST}
     install -m 0644 ${B}/boot.img ${D}/${KERNEL_IMAGEDEST}


### PR DESCRIPTION
https://github.com/AsteroidOS/meta-asteroid/pull/238 renamed the boot image to just boot.img for abootimg and mkboot while keeping the distro and machine name for the mkbootimg method.

This makes them all consistent.