### PR TITLE
Disable empty root login, root ssh login

### DIFF
--- a/classes/asteroid-image.bbclass
+++ b/classes/asteroid-image.bbclass
@@ -6,7 +6,7 @@ LICENSE = "GPL-2.0-only"
 inherit populate_sdk_qt6
 inherit asteroid-users
 
-IMAGE_FEATURES += "package-management empty-root-password allow-empty-password allow-root-login"
+IMAGE_FEATURES += "package-management allow-empty-password"
 
 IMAGE_INSTALL += " \
 kernel-modules base-files base-passwd systemd busybox iproute2 connman pam-plugin-loginuid bluez5 polkit polkit-group-rule-datetime sudo \


### PR DESCRIPTION
Yocto will set an invalid root password, disallowing any password login. Root login will also be disabled in sshd_config

For usecases where it's needed, root empty password can be re-enabled by running:
sudo passwd -d root

root ssh login can be reenabled with:
sudo sed -i 's/^[#[:space:]]*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config