### PR TITLE
old-kernel-gcc-hdrs: avoid $(()) so bitbake can parse the class

### DIFF
--- a/classes/old-kernel-gcc-hdrs.bbclass
+++ b/classes/old-kernel-gcc-hdrs.bbclass
@@ -13,7 +13,7 @@ do_configure:prepend() {
 
     for v in $(seq 4 "${to}"); do
         hdr="${S}/include/linux/compiler-gcc${v}.h"
-        [ -e "${hdr}" ] || echo "#include <linux/compiler-gcc$((v - 1)).h>" > "${hdr}"
+        [ -e "${hdr}" ] || echo "#include <linux/compiler-gcc$(expr $v - 1).h>" > "${hdr}"
     done
 }
 


### PR DESCRIPTION
bitbake parses shell tasks with its own pysh parser rather than a real shell, and pysh has never implemented POSIX arithmetic expansion. The $((v - 1)) in the compiler-header shim therefore raised "NotImplementedError: $((" at finalise time, breaking parsing of every recipe that inherits this class (e.g. linux-sparrow_mm-mr1).

Use $(expr $v - 1) instead. It produces the same value and relies only on command substitution, which pysh already supports (the KERNEL_CC dumpversion line in the same function uses it).

I could swear I'd tested it before pushing but I must have tested the wonrg branch - ugh, that's what I get for working on too many things at the same time.