### PR TITLE
mapplauncherd-booster-asteroid: Depend on qtsensors-qmlplugins

### DIFF
--- a/recipes-nemomobile/mapplauncherd/mapplauncherd-booster-asteroid_git.bb
+++ b/recipes-nemomobile/mapplauncherd/mapplauncherd-booster-asteroid_git.bb
@@ -11,7 +11,7 @@ S = "${WORKDIR}/git"
 inherit qt6-qmake
 
 DEPENDS += "mapplauncherd mapplauncherd-qt qtdeclarative qtbase"
-RDEPENDS:${PN} += "mapplauncherd"
+RDEPENDS:${PN} += "mapplauncherd qtsensors-qmlplugins"
 
 do_configure:prepend() {
     sed -i "s@INCLUDEPATH += /usr/include/applauncherd/@INCLUDEPATH += ${STAGING_INCDIR}/applauncherd ${STAGING_INCDIR}/mdeclarativecache6/@" ${S}/booster-asteroid.pro


### PR DESCRIPTION
On some watches like sparrow, we don't have sensors support so we don't install any app that would use a sensor and nothing pulls QtSensors as a dependency.

Since our booster scripts now import QtSensors, this means they fail to load on those watches so app startup becomes very slow.

An alternative could have been to drop QtSensors from the booster but I think it's ok like that.