### PR TITLE
mkcal: Build without timed support

### DIFF
--- a/recipes-qt/qt6/mkcal_git.bb
+++ b/recipes-qt/qt6/mkcal_git.bb
@@ -10,5 +10,5 @@ PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 inherit qt6-cmake pkgconfig
 
-DEPENDS += "extra-cmake-modules qtbase kcalendarcore timed libical sqlite3 util-linux"
+DEPENDS += "extra-cmake-modules qtbase kcalendarcore libical sqlite3 util-linux"
 EXTRA_OECMAKE += " -DBUILD_TESTS=OFF -DBUILD_PLUGINS=OFF -DENABLE_QT6=ON"


### PR DESCRIPTION
Technically, our calendar could register some alarms to timed but 1- we never used this feature 2- we want to get rid of timed sooner or later (and maybe use systemd timers instead ?) so let's build mkcal without timed support to drop one of the dependencies to timed.