### PR TITLE
Ceres reboot rule: fix polkit-1/rules.d ownership

### DIFF
--- a/recipes-asteroid/asteroid-apps/polkit-ceres-rule-reboot.bb
+++ b/recipes-asteroid/asteroid-apps/polkit-ceres-rule-reboot.bb
@@ -8,8 +8,7 @@ SRC_URI = "file://30-org.freedesktop.login1.rules"
 S = "${UNPACKDIR}"
 
 do_install() {
-        install -m 700 -d ${D}${datadir}/polkit-1/rules.d
-        chown polkitd:root ${D}/${datadir}/polkit-1/rules.d
+        install -m 755 -d ${D}${datadir}/polkit-1/rules.d
         install -m 0755 ${UNPACKDIR}/30-org.freedesktop.login1.rules ${D}${datadir}/polkit-1/rules.d
 }
 


### PR DESCRIPTION
The ownership and permissions that we installed differed from the ones installed in the systemd package. When packaging with DNF, this would cause a conflict.
Change ours to match systemd.