### PR TITLE
android.inc: formalise qa skips

### DIFF
--- a/recipes-android/android/android.inc
+++ b/recipes-android/android/android.inc
@@ -24,12 +24,10 @@ do_install() {
     rm ${D}${includedir}/android/android-headers.pc
 }
 
-# Precompiled libraries, INSANE_SKIP all.
-do_package_qa() {
-}
-
-# Allow empty main package since the -dev package depends on it
-ALLOW_EMPTY:${PN} = "1"
+# We don't ship libstdc++.so as part of these tarballs. 
+# This library exists on these watches' system partitions, which we mount during boot.
+# Convince yocto that we already have this file.
+RPROVIDES:android-system += "libstdc++.so"
 
 PACKAGES =+ "android-system android-headers"
 FILES:android-system = "/usr"


### PR DESCRIPTION
I spotted issues here while trying to build with RPM/DNF packages, so I spent some time trying to untangle the QA skips. 

I'm not actually sure what the `ALLOW_EMPTY` did, but removing it hasn't broken ipk or rpm builds. This might need a review from @MagneFire , since he's the one who originally added that line. 

The 'fake' libstdc++.so RPROVIDE is a hack. The tarballs link to libstdc++, which we provide when we mount the system partition at boot time. 
Instead of adding the RPROVIDE, this could be worked around using `INSANE_SKIP:android-system += "file-rdeps"`. however, DNF does its own per-file dependency check, and there doesn't seem to be a way to skip that. 
Since it's just one vendor-provided file that these tarballs depend on, I feel this hack isn't too egregious.

Watches that package their own system directory (basically everything older than oreo) also need to be build-tested with RPM, though they're likely to have other quirks.