### PR TITLE
fuse: drop bbappend, no longer pulled into the image

### DIFF
--- a/recipes-support/fuse/fuse_%.bbappend
+++ b/recipes-support/fuse/fuse_%.bbappend
@@ -1,8 +1,0 @@
-do_install:append() {
-    # Remove /etc/modules-load.d/fuse.conf which makes the systemd-modules-load.service fail
-    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
-        rm -r ${D}${sysconfdir}/modules-load.d
-    fi
-
-    echo "user_allow_other" >> ${D}${sysconfdir}/fuse.conf
-}


### PR DESCRIPTION
Nothing in asteroid-image depends on fuse, directly or transitively: `bitbake -g asteroid-image` yields a 474-recipe / 35753-edge task graph with no fuse node, and a full image build produces no fuse/libfuse ipk. The bbappend therefore never runs as part of an image build.

Its two remaining effects don't justify keeping it around:
 - Removing /etc/modules-load.d/fuse.conf worked around systemd-modules-load.service failing to modprobe the built-in (CONFIG_FUSE_FS=y) fuse module -- only relevant if fuse is installed.
 - user_allow_other in /etc/fuse.conf has had no consumer in the tree since it was added in 2017.

If fuse is ever reintroduced it will likely be fuse3, which this fuse_% append wouldn't match anyway, so the workaround would need revisiting against the current recipe regardless.