### PR TITLE
qml-asteroid: pull in qtimageformats-plugins for webp

### DIFF
--- a/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
+++ b/recipes-asteroid/qml-asteroid/qml-asteroid_git.bb
@@ -11,7 +11,7 @@ S = "${WORKDIR}/git"
 inherit qt6-cmake pkgconfig
 
 DEPENDS += "extra-cmake-modules qtdeclarative qtsvg qtvirtualkeyboard mapplauncherd-booster-asteroid qtdeclarative-native qtshadertools qtshadertools-native qt5compat"
-RDEPENDS:${PN} += "asteroid-machine-config qtsvg-plugins qtvirtualkeyboard asteroid-icons-ion"
+RDEPENDS:${PN} += "asteroid-machine-config qtsvg-plugins qtvirtualkeyboard asteroid-icons-ion qtimageformats-plugins"
 
 FILES:${PN} += "/usr/lib /usr/share/icons/asteroid/"
 FILES:${PN}-dbg += "/usr/lib/qml/org/asteroid/controls/.debug/ /usr/lib/qml/QtQuick/Controls/Styles/Asteroid/.debug/"


### PR DESCRIPTION
Adds `qtimageformats-plugins` to qml-asteroid's runtime dependencies so the Qt webp image handler (`libqwebp`) is installed on the image, next to the existing `qtsvg-plugins`. qml-asteroid is the base library every app and watchface pulls in, so webp decode/encode becomes available everywhere `QImageReader`/`QImageWriter` are used.

**Why**

The `qtimageformats` recipe already builds webp by default (its PACKAGECONFIG enables webp against `libwebp`, which is already on the image via the webkit stack). Nothing installed the plugin until now, so `QImageReader::supportedImageFormats()` excluded webp and `Image { source: "*.webp" }` had no handler. This unblocks on-device watchface preview generation and lets AsteroidOS move stored images off the heavier PNG format.

**Verification**

Built an `asteroid-image` for beluga with only this change and flashed it. Confirmed `qtimageformats-plugins 6.11.2` in the image manifest, `libqwebp.so` installed to `/usr/lib/plugins/imageformats/` beside the working `libqsvg.so`, and a real `.webp` decoding on-device (`qml -platform offscreen` reports `Image.Ready` with correct dimensions, and a fullscreen webp renders as a Wayland client under lipstick).

No `PR` bump, matching how `qtsvg-plugins` was originally added to this recipe.

---

*Disclosure: an LLM was used to document the process, execute the on-device tests, and detail this PR message.*
