### PR TITLE
Readd and fix nemo-qml-plugin notifications

### DIFF
--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-notifications/0001-Fix-qdusxml2cpp-search-path.patch
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-notifications/0001-Fix-qdusxml2cpp-search-path.patch
@@ -1,0 +1,20 @@
+From cfc90303e9e5e40540c8b47250bb2c18b3fa3ebb Mon Sep 17 00:00:00 2001
+From: Davids Paskevics <davids.paskevics@gmail.com>
+Date: Mon, 24 Nov 2025 13:26:39 +0100
+Upstream-Status: Inappropriate
+Subject: [PATCH] Fix qdusxml2cpp search path
+
+---
+ src/src.pro | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/src.pro b/src/src.pro
+index 7a93631..ef21326 100644
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -1,4 +1,4 @@
+-system($$[QT_HOST_BINS]/qdbusxml2cpp org.freedesktop.Notifications.xml -p notificationmanagerproxy -c NotificationManagerProxy -i notification_p.h)
++system(qdbusxml2cpp org.freedesktop.Notifications.xml -p notificationmanagerproxy -c NotificationManagerProxy -i notification_p.h)
+ 
+ TEMPLATE = lib
+ TARGET = nemonotifications-qt$${QT_MAJOR_VERSION}

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-notifications_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-notifications_git.bb
@@ -1,0 +1,19 @@
+SUMMARY = "QML Plugin for notifications on Nemo"
+HOMEPAGE = "https://github.com/sailfishos/nemo-qml-plugin-notifications"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b2ea859fa337fbb664575a8061833d99"
+
+SRC_URI = "git://github.com/sailfishos/nemo-qml-plugin-notifications.git;protocol=https;branch=master \
+           file://0001-Fix-qdusxml2cpp-search-path.patch \
+           "
+SRCREV = "d4d0a0ce8257b90293b8df469830f0e288faeeae"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+inherit qt6-qmake
+
+DEPENDS += "qtdeclarative"
+
+FILES:${PN}-dbg += "/opt /usr/lib/qml/Nemo/Notifications/.debug"
+FILES:${PN}-dev += "/usr/lib/libnemonotifications-qt5.prl"
+FILES:${PN} += "/usr/lib/qml/Nemo/Notifications/"

--- a/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-notifications_git.bb
+++ b/recipes-nemomobile/nemo-qml-plugins/nemo-qml-plugin-notifications_git.bb
@@ -15,5 +15,5 @@ inherit qt6-qmake
 DEPENDS += "qtdeclarative"
 
 FILES:${PN}-dbg += "/opt /usr/lib/qml/Nemo/Notifications/.debug"
-FILES:${PN}-dev += "/usr/lib/libnemonotifications-qt5.prl"
+FILES:${PN}-dev += "/usr/lib/libnemonotifications-qt6.prl"
 FILES:${PN} += "/usr/lib/qml/Nemo/Notifications/"


### PR DESCRIPTION
This is a dependency for asteroid-weatherfetch, which seems to have been missed when this plugin was removed