### PR TITLE
qtmultimedia: Stop PulseAudio streams running on 21ms of buffer

### DIFF
--- a/recipes-qt/qt6/qtmultimedia/0001-pulseaudio-Do-not-cap-the-server-side-buffer-at-1024-.patch
+++ b/recipes-qt/qt6/qtmultimedia/0001-pulseaudio-Do-not-cap-the-server-side-buffer-at-1024-.patch
@@ -1,0 +1,55 @@
+From: Timo Könnecke <github.com/moWerk>
+Date: Sun, 16 Aug 2026 14:00:00 +0200
+Subject: [PATCH] pulseaudio: Do not cap the server side buffer at 1024 frames
+
+QPulseAudioSinkStream::startStream() sets pa_buffer_attr.maxlength to 1024
+frames and leaves tlength at -1. maxlength is PulseAudio's total buffer for
+the stream and the server clamps tlength down to it, so every Qt stream runs
+on 21ms of buffer at 48kHz regardless of what the application requested
+through QAudioSink::setBufferSize(). No public API can influence maxlength.
+
+Any missed wakeup is then an underrun. On a single core device this is
+continuous: measured 1182 implicit underruns in 64 seconds of a steady tone,
+and 0 with this change.
+
+m_hardwareBufferFrames is effectively never set on this path.
+setHardwareBufferFrames() has one caller, the spatial audio engine, which is
+unreachable from QAudioSink and QSoundEffect, so value_or(1024) always
+applies. In dev the field is renamed m_nativePeriodFrames, which makes the
+mistake clearer: a period is one wakeup quantum, not a whole buffer.
+
+Leave maxlength to the server and derive tlength from the ringbuffer the
+stream can actually supply, taking half of it. PulseAudio requests a whole
+tlength per callback, so setting tlength equal to the ringbuffer lets a
+single callback drain it and the following request finds it empty; the
+shortfall is padded with silence and written anyway, which is audible as
+crackle and is invisible to PulseAudio because a full buffer still arrives.
+Half leaves the producer room to refill.
+
+Upstream-Status: Pending
+---
+diff --git i/src/multimedia/pulseaudio/qpulseaudiosink.cpp w/src/multimedia/pulseaudio/qpulseaudiosink.cpp
+index 3c6a8f6..27d173e 100644
+--- i/src/multimedia/pulseaudio/qpulseaudiosink.cpp
++++ w/src/multimedia/pulseaudio/qpulseaudiosink.cpp
+@@ -222,9 +222,18 @@ void QPulseAudioSinkStream::uninstallCallbacks()
+ 
+ bool QPulseAudioSinkStream::startStream(StreamType streamType)
+ {
++    // maxlength is the server's total buffer for the stream and tlength is
++    // clamped to it, so the 1024 frame default caps every stream at 21ms at
++    // 48kHz however large a buffer the application asked for.
++    //
++    // tlength is half the ringbuffer rather than all of it: PulseAudio requests
++    // a whole tlength in a single callback, so making them equal lets one
++    // callback drain the ringbuffer completely, and the next request arrives
++    // before the producer thread has refilled it. The shortfall is then padded
++    // with silence and written anyway, which is audible.
+     pa_buffer_attr attr{
+-        .maxlength = uint32_t(m_format.bytesForFrames(m_hardwareBufferFrames.value_or(1024))),
+-        .tlength = uint32_t(-1),
++        .maxlength = uint32_t(-1),
++        .tlength = uint32_t(ringbufferSizeInBytes() / 2),
+         .prebuf = uint32_t(-1),
+         .minreq = uint32_t(-1),
+         .fragsize = uint32_t(-1),

--- a/recipes-qt/qt6/qtmultimedia_git.bbappend
+++ b/recipes-qt/qt6/qtmultimedia_git.bbappend
@@ -1,3 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/qtmultimedia:"
+SRC_URI:append = " \
+        file://0001-pulseaudio-Do-not-cap-the-server-side-buffer-at-1024-.patch \
+"
+
 PACKAGECONFIG:append = " gstreamer "
 PACKAGECONFIG:remove = " spatialaudio_quick3d "
 EXTRA_QMAKEVARS_PRE:remove = "CONFIG+=done_config_gstreamer"


### PR DESCRIPTION
Fixes the continuous chopping in AsteroidOS/asteroid#342.

## The bug

`QPulseAudioSinkStream::startStream()` sets `pa_buffer_attr.maxlength` to 1024
frames and leaves `tlength` at `-1`. `maxlength` is PulseAudio's total buffer for
the stream and the server clamps `tlength` down to it, so every Qt audio stream
runs on 21ms of buffer at 48kHz no matter what the application asked for.

No public API can change this. `setBufferSize()` and `setBufferFrameCount()` both
size Qt's internal ringbuffer and never reach `pa_buffer_attr`. PulseAudio's own
log shows the request being discarded:

```
requested   maxlength=2048, tlength=8704, prebuf=8194
sanitized   maxlength=2048, tlength=2048, prebuf=1538
```

The application asked for 8704 bytes and was given 2048. For comparison,
GStreamer's pulsesink asks for roughly 200ms.

## The change

```c
-    .maxlength = uint32_t(m_format.bytesForFrames(m_hardwareBufferFrames.value_or(1024))),
-    .tlength = uint32_t(-1),
+    .maxlength = uint32_t(-1),
+    .tlength = uint32_t(ringbufferSizeInBytes() / 2),
```

Half the ringbuffer rather than all of it, because PulseAudio requests a whole
`tlength` per callback: making them equal lets one callback drain the ringbuffer
and the next request finds it empty. Qt then pads the shortfall with silence and
writes it anyway, which is audible and invisible to PulseAudio because a full
buffer still arrives. An instrumented build counted that padding over a 46
second tone:

| tlength | beluga pads | beluga underruns | sturgeon pads |
|---|---|---|---|
| whole ringbuffer | 55 | 0 | 2 |
| **half** | **13** | **0** | **1** |
| quarter | 21 | 1 | 0 |

A quarter is better on the faster watch and worse on the slower one: smaller
requests arrive more often, giving a slow producer more chances to be late.
Half helps the weakest device without reintroducing underruns anywhere.

## Result

Same watch, same tone, only the library swapped:

| | unpatched | patched |
|---|---|---|
| tone length | 64 s | 61 s |
| `Implicit underrun` | **1182** | **0** |

Reproduced on a second device model, sturgeon: 997 unpatched, 0 patched.

## Alternatives considered

Each was tested on hardware and rejected before landing on the buffer:

| candidate | how it was tested | result |
|---|---|---|
| PulseAudio has no realtime scheduling | `LimitRTPRIO` drop-in, confirmed the IO threads reached SCHED_RR prio 5 | no change. Real bug, worth fixing separately |
| 48kHz mono resampled to the sink's 44.1kHz stereo | same tone via `gst-launch` at both formats, `pactl` confirming when the resampler engaged | clean at both. Also refuted on sturgeon, whose sink is natively 48kHz |
| `PA_STREAM_ADJUST_LATENCY` | rebuilt without the flag | no change |
| application buffer and thread priority | raised `setBufferSize`, renice'd the client | no change, and this is what showed the public API cannot reach `maxlength` |
| `hardwareBufferFrames` 1024 to 4096 | rebuilt with a larger fallback | symptom changed but persisted: the same bug half fixed |

The non-Qt control throughout was `gst-launch` through the same sink on the same
device, which does not chop.

## Scope

This fixes the continuous chopping. It does not claim to explain why a deadline
gets missed in the first place, and it does not address the quieter start and
stop artefacts, which are still being investigated and are tracked in
asteroid#342.

The code is unchanged from Qt 6.8 through `dev`, so this is not specific to our
Qt version, and no matching report exists upstream. The patch carries
`Upstream-Status: Pending`.

Claude was used as a coding and review assistant throughout.
