### PR TITLE
Restore gnss functionality

### DIFF
--- a/recipes-navigation/qtpositioning-geoclue/qtpositioning-geoclue.bb
+++ b/recipes-navigation/qtpositioning-geoclue/qtpositioning-geoclue.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Geoclue 0 plugin for QtPositioning Qt6"
+HOMEPAGE = "https://github.com/beroset/qtpositioning-geoclue"
+LICENSE = "LGPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e6a600fd5e1d9cbde2d983680233ad02"
+SRC_URI = "git://github.com/beroset/qtpositioning-geoclue.git;protocol=https;branch=main"
+SRCREV = "c701fde6184622a28d3dbf67b8817cc05efcad3d"
+S = "${WORKDIR}/git"
+DEPENDS = "qtbase qtpositioning"
+inherit qt6-cmake pkgconfig
+
+FILES:${PN} += "/usr/lib/"
+

--- a/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris.inc
+++ b/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris.inc
@@ -21,8 +21,4 @@ inherit qt6-qmake pkgconfig
 # Ensures that the root sources can be found.
 B = "${S}"
 
-do_install:append() {
-    chmod 04755 ${D}/usr/libexec/geoclue-hybris
-}
-
 FILES:${PN} += "/usr/share/dbus-1 /usr/share/geoclue-providers /usr/lib/systemd/user"


### PR DESCRIPTION
This fixes https://github.com/AsteroidOS/asteroid/issues/340 by restoring the functionality of geoclue0 in conjunction with QtPositioning.  This is done by adding in a new plugin for QtPositioning and updating the recipe for geoclue-hybris-providers to omit suid root setting that was preventing it from working under Qt6. 