### PR TITLE
distro: fix package feed architecture names

### DIFF
--- a/conf/distro/asteroid.conf
+++ b/conf/distro/asteroid.conf
@@ -42,7 +42,7 @@ FILESYSTEM_PERMS_TABLES = "files/fs-perms.txt files/asteroidos-fs-perms.txt"
 
 PACKAGE_FEED_URIS = "https://release.asteroidos.org/nightlies/"
 PACKAGE_FEED_BASE_PATHS = "ipk"
-PACKAGE_FEED_ARCHS = "all anthias armv7athf-neon armv7vehf-neon bass beluga catfish core2-32 dory emulator firefish harmony hoki inharmony koi lenok minnow mooneye narwhal nemo pike ray rinato rubyfish sawfish skipjack smelt sparrow sparrow-mainline sprat sturgeon swift tetra triggerfish wren"
+PACKAGE_FEED_ARCHS = "all anthias armv7at2hf-neon armv7vehf-neon bass beluga catfish core2-32 dory emulator firefish harmony hoki inharmony koi lenok minnow mooneye narwhal nemo pike ray rinato rubyfish sawfish skipjack smelt sparrow sparrow_mainline sprat sturgeon swift tetra triggerfish wren"
 
 SKIP_META_GNOME_SANITY_CHECK = "1"
 


### PR DESCRIPTION
Correct two entries in `PACKAGE_FEED_ARCHS` so generated opkg source URLs match the published nightly feed directories:

- `armv7athf-neon` → `armv7at2hf-neon`
- `sparrow-mainline` → `sparrow_mainline`

Both corrected `Packages.gz` URLs return HTTP 200. On a sawfish nightly image, the previous names caused `opkg update` to abort; with these replacements it completes successfully.