### PR TITLE
ngfd: Play notification sound via x-maemo media role

### DIFF
--- a/recipes-nemomobile/ngfd/ngfd/events.d/notification.ini
+++ b/recipes-nemomobile/ngfd/ngfd/events.d/notification.ini
@@ -1,3 +1,3 @@
 [notification]
 sound.filename = /usr/share/sounds/notification.wav
-sound.stream.media.role = notification
+sound.stream.media.role = x-maemo


### PR DESCRIPTION
AsteroidOS volume control always sets the mainvolume. mainvolume is mapped to the x-maemo media role.
This role is also used for any streams that don't set a role.

Recently, notification sound was moved away from QtMultimedia to ngfd. This resulted in notifications always sounding at 100% regardless of volume level set in the quickpanel or settings.

Using the x-maemo media role fixes this issue.

This fixes https://github.com/AsteroidOS/asteroid-launcher/issues/296.