### PR TITLE
geoclue-provider-hybris: drop setuid bit, fixes DBUS_SESSION_BUS_ADDRESS stripping

### DIFF
--- a/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris.inc
+++ b/recipes-nemomobile/geoclue-providers/geoclue-provider-hybris.inc
@@ -20,8 +20,16 @@ inherit qt6-qmake pkgconfig
 # Ensures that the root sources can be found.
 B = "${S}"
 
+# NOTE: this used to be setuid-root (04755). On at least one port (hoki,
+# see AsteroidOS/meta-smartwatch#252) that causes glibc/D-Bus to strip
+# DBUS_SESSION_BUS_ADDRESS from the environment for setuid processes (a
+# real, documented security hardening behavior - real-uid != effective-uid
+# triggers it), which makes QDBusConnection::sessionBus() fail to connect
+# and registerObject() fail with a qFatal crash on startup. The GNSS
+# binder HAL access this binary needs does not require root - confirmed
+# working as a normal, unprivileged user. Dropping the setuid bit.
 do_install:append() {
-    chmod 04755 ${D}/usr/libexec/geoclue-hybris
+    chmod 0755 ${D}/usr/libexec/geoclue-hybris
 }
 
 FILES:${PN} += "/usr/share/dbus-1 /usr/share/geoclue-providers /usr/lib/systemd/user"


### PR DESCRIPTION
Real bug found and fixed while bringing up GPS on my hoki (Skagen Falster Gen 6) - full writeup in AsteroidOS/meta-smartwatch#252.

`geoclue-hybris` is installed setuid-root (`04755`). A setuid-root process has real-uid != effective-uid, which is exactly the condition under which glibc/D-Bus strip environment variables like `DBUS_SESSION_BUS_ADDRESS` from the process at the dynamic-loader level, before `main()` ever runs - a real, documented security hardening behavior, not a glibc/D-Bus bug.

That makes `QDBusConnection::sessionBus()` fail to connect and the provider crash immediately on startup with `qFatal("Failed to register object ...")`, confirmed via `QDBusConnection::lastError()`:
```
Using X11 for dbus-daemon autolaunch was disabled at compile time, set your DBUS_SESSION_BUS_ADDRESS instead
```

```diff
- chmod 04755 ${D}/usr/libexec/geoclue-hybris
+ chmod 0755 ${D}/usr/libexec/geoclue-hybris
```

Confirmed the GNSS binder HAL access this binary needs does not actually require root on the hoki port - it runs fine as the normal, unprivileged session user, and confirmed working via a real cold reboot (`busctl` introspection returns the full expected interface set, service correctly sits dormant until D-Bus auto-activation).

I do not know if any other device relies on the elevated privilege for a reason I am not aware of - flagging that possibility for review, but I could not find one and this should be safe generally.

Used Claude Code to help me track this down - not a kernel/D-Bus developer by trade, just followed the crash to its real root cause. Sharing it back in case it helps someone else.
