### PR TITLE
qt6-qpa-hwcomposer-plugin: Refresh patches

### DIFF
--- a/recipes-qt/qt6/qt6-qpa-hwcomposer-plugin/004-Includes-sync.h-which-provides-sync_wait.patch
+++ b/recipes-qt/qt6/qt6-qpa-hwcomposer-plugin/004-Includes-sync.h-which-provides-sync_wait.patch
@@ -1,38 +1,42 @@
-From ee32e808edc73b208dc787530e50013ee60775c6 Mon Sep 17 00:00:00 2001
+From dbf1f0b85bcc2343b3a60f461c7251f269450571 Mon Sep 17 00:00:00 2001
 From: Florent Revest <revestflo@gmail.com>
 Date: Thu, 6 Aug 2015 14:32:10 +0200
 Subject: [PATCH] Includes sync.h which provides sync_wait
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Upstream-Status: Inappropriate
-
+Signed-off-by: Darrel Griët <dgriet@gmail.com>
 ---
  hwcomposer/hwcomposer_backend_v10.h | 1 +
  hwcomposer/hwcomposer_backend_v11.h | 1 +
  2 files changed, 2 insertions(+)
 
 diff --git a/hwcomposer/hwcomposer_backend_v10.h b/hwcomposer/hwcomposer_backend_v10.h
-index bc7055a..628557f 100644
+index 0ad3e17..8debfec 100644
 --- a/hwcomposer/hwcomposer_backend_v10.h
 +++ b/hwcomposer/hwcomposer_backend_v10.h
-@@ -48,6 +48,7 @@
-
- #include <QWaitCondition>
- #include <QMutex>
-+#include <sync/sync.h>
- #include <QObject>
+@@ -53,6 +53,7 @@
  #include <QBasicTimer>
  #include <QSet>
+ #include <QWindow>
++#include <sync/sync.h>
+ 
+ class HwComposerBackend_v10 : public QObject, public HwComposerBackend {
+ public:
 diff --git a/hwcomposer/hwcomposer_backend_v11.h b/hwcomposer/hwcomposer_backend_v11.h
-index 46b34d3..8281925 100644
+index 2bf91c9..b25dc05 100644
 --- a/hwcomposer/hwcomposer_backend_v11.h
 +++ b/hwcomposer/hwcomposer_backend_v11.h
 @@ -45,6 +45,7 @@
  #ifdef HWC_PLUGIN_HAVE_HWCOMPOSER1_API
-
+ 
  #include "hwcomposer_backend.h"
 +#include <sync/sync.h>
-
+ 
  // libhybris access to the native hwcomposer window
  #include <hwcomposer_window.h>
---
-2.5.0
+-- 
+2.50.0
+


### PR DESCRIPTION
cb97e9290f12951e63d1279b8648ca40dc66195e refreshed the 004 patch, but that resulted in issues:
ERROR: qt6-qpa-hwcomposer-plugin-6.3.0+git-r0 do_patch: QA Issue: Fuzz detected:

Applying patch 004-Includes-sync.h-which-provides-sync_wait.patch patching file hwcomposer_backend_v10.h
Hunk #1 succeeded at 48 with fuzz 2.
patching file hwcomposer_backend_v11.h

The context lines in the patches can be updated with devtool:

    devtool modify qt6-qpa-hwcomposer-plugin
    devtool finish --force-patch-refresh qt6-qpa-hwcomposer-plugin <layer_path>

Don't forget to review changes done by devtool!

This is fixed by refreshing the patch.