### PR TITLE
layer.conf: publish a Python 3 runtime in the opkg feed

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PRIORITY_asteroid-layer = "7"
 
 LAYERSERIES_COMPAT_asteroid-layer = "whinlatter"
 
-PACKAGE_FEED += "gdb strace"
+PACKAGE_FEED += "gdb strace python3"


### PR DESCRIPTION
Replaces AsteroidOS/meta-smartwatch#339, which scoped this to `sawfish`. As pointed out in review on AsteroidOS/meta-asteroid#326, there is nothing machine-specific about it: `python3` is a plain oe-core recipe, so the general package feed is the right place and every machine benefits.

AsteroidOS images ship no scripting interpreter, so anything written on-device has to be a shell script. The pinned oe-core already provides `python3`; listing it in `PACKAGE_FEED` builds it for the feed without adding it to any image -- exactly how `gdb` and `strace` are handled today.

`PACKAGE_FEED` entries become sstate build-depends of `asteroid-package-feed`, and `generate_index_files` indexes the whole deploy directory, so every IPK the recipe produces is covered and the split packages are installable too:

```
opkg update && opkg install python3-modules
```

Fixes AsteroidOS/meta-asteroid#326

🤖 Generated with [Claude Code](https://claude.com/claude-code)